### PR TITLE
Adds support for opt_archive parameter in pp_ser.py Python preprocessor

### DIFF
--- a/src/serialbox-fortran/utils_ppser.f90
+++ b/src/serialbox-fortran/utils_ppser.f90
@@ -76,13 +76,13 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprec
   IF ( .NOT. ppser_initialized ) THEN
     IF ( PRESENT(mpi_rank) ) THEN
       WRITE(suffix, '(A5,I0)') "_rank", mpi_rank
-      IF ( PRESENT(opt_archive) )
+      IF ( PRESENT(opt_archive) ) THEN
         CALL fs_create_serializer(directory, TRIM(prefix)//TRIM(suffix), 'w', ppser_serializer, opt_archive)
       ELSE
         CALL fs_create_serializer(directory, TRIM(prefix)//TRIM(suffix), 'w', ppser_serializer)
       END IF
     ELSE
-      IF ( PRESENT(opt_archive) )
+      IF ( PRESENT(opt_archive) ) THEN
         CALL fs_create_serializer(directory, TRIM(prefix), 'w', ppser_serializer, opt_archive)
       ELSE
         CALL fs_create_serializer(directory, TRIM(prefix), 'w', ppser_serializer)
@@ -92,13 +92,13 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprec
     IF ( PRESENT(mode) ) ppser_mode = mode
     IF ( PRESENT(prefix_ref) ) THEN
       IF ( PRESENT(mpi_rank) ) THEN
-        IF ( PRESENT(opt_archive) )
+        IF ( PRESENT(opt_archive) ) THEN
           CALL fs_create_serializer(directory, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref, opt_archive)
         ELSE
           CALL fs_create_serializer(directory, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref)
         END IF
       ELSE
-        IF ( PRESENT(opt_archive) )
+        IF ( PRESENT(opt_archive) ) THEN
           CALL fs_create_serializer(directory, TRIM(prefix_ref), 'r', ppser_serializer_ref, opt_archive)
         ELSE
           CALL fs_create_serializer(directory, TRIM(prefix_ref), 'r', ppser_serializer_ref)

--- a/src/serialbox-fortran/utils_ppser.f90
+++ b/src/serialbox-fortran/utils_ppser.f90
@@ -58,13 +58,14 @@ CONTAINS
 
 !============================================================================
 
-SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprecision, rperturb, realtype)
+SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprecision, rperturb, realtype, opt_archive)
   CHARACTER(LEN=*), INTENT(IN)           :: directory, prefix
   INTEGER, OPTIONAL, INTENT(IN)          :: mode
   CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: prefix_ref
   INTEGER, OPTIONAL, INTENT(IN)          :: mpi_rank
   REAL(KIND=8), OPTIONAL, INTENT(IN)     :: rprecision, rperturb
   INTEGER, OPTIONAL, INTENT(IN)          :: realtype
+  CHARACTER(LEN=*), INTENT(IN), OPTIONAL :: opt_archive
 
   CHARACTER(LEN=1), DIMENSION(128)       :: buffer
   CHARACTER(LEN=15)                      :: suffix
@@ -75,17 +76,17 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprec
   IF ( .NOT. ppser_initialized ) THEN
     IF ( PRESENT(mpi_rank) ) THEN
       WRITE(suffix, '(A5,I0)') "_rank", mpi_rank
-      CALL fs_create_serializer(directory, TRIM(prefix)//TRIM(suffix), 'w', ppser_serializer)
+      CALL fs_create_serializer(directory, TRIM(prefix)//TRIM(suffix), 'w', ppser_serializer, opt_archive)
     ELSE
-      CALL fs_create_serializer(directory, TRIM(prefix), 'w', ppser_serializer)
+      CALL fs_create_serializer(directory, TRIM(prefix), 'w', ppser_serializer, opt_archive)
     END IF
     CALL fs_create_savepoint('', ppser_savepoint)
     IF ( PRESENT(mode) ) ppser_mode = mode
     IF ( PRESENT(prefix_ref) ) THEN
       IF ( PRESENT(mpi_rank) ) THEN
-        CALL fs_create_serializer(directory, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref)
+        CALL fs_create_serializer(directory, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref, opt_archive)
       ELSE
-        CALL fs_create_serializer(directory, TRIM(prefix_ref), 'r', ppser_serializer_ref)
+        CALL fs_create_serializer(directory, TRIM(prefix_ref), 'r', ppser_serializer_ref, opt_archive)
       END IF
     END IF
   END IF

--- a/src/serialbox-fortran/utils_ppser.f90
+++ b/src/serialbox-fortran/utils_ppser.f90
@@ -58,14 +58,14 @@ CONTAINS
 
 !============================================================================
 
-SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprecision, rperturb, realtype, opt_archive)
+SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprecision, rperturb, realtype, archive)
   CHARACTER(LEN=*), INTENT(IN)           :: directory, prefix
   INTEGER, OPTIONAL, INTENT(IN)          :: mode
   CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: prefix_ref
   INTEGER, OPTIONAL, INTENT(IN)          :: mpi_rank
   REAL(KIND=8), OPTIONAL, INTENT(IN)     :: rprecision, rperturb
   INTEGER, OPTIONAL, INTENT(IN)          :: realtype
-  CHARACTER(LEN=*), INTENT(IN), OPTIONAL :: opt_archive
+  CHARACTER(LEN=*), INTENT(IN), OPTIONAL :: archive
 
   CHARACTER(LEN=1), DIMENSION(128)       :: buffer
   CHARACTER(LEN=15)                      :: suffix
@@ -76,14 +76,14 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprec
   IF ( .NOT. ppser_initialized ) THEN
     IF ( PRESENT(mpi_rank) ) THEN
       WRITE(suffix, '(A5,I0)') "_rank", mpi_rank
-      IF ( PRESENT(opt_archive) ) THEN
-        CALL fs_create_serializer(directory, TRIM(prefix)//TRIM(suffix), 'w', ppser_serializer, opt_archive)
+      IF ( PRESENT(archive) ) THEN
+        CALL fs_create_serializer(directory, TRIM(prefix)//TRIM(suffix), 'w', ppser_serializer, archive)
       ELSE
         CALL fs_create_serializer(directory, TRIM(prefix)//TRIM(suffix), 'w', ppser_serializer)
       END IF
     ELSE
-      IF ( PRESENT(opt_archive) ) THEN
-        CALL fs_create_serializer(directory, TRIM(prefix), 'w', ppser_serializer, opt_archive)
+      IF ( PRESENT(archive) ) THEN
+        CALL fs_create_serializer(directory, TRIM(prefix), 'w', ppser_serializer, archive)
       ELSE
         CALL fs_create_serializer(directory, TRIM(prefix), 'w', ppser_serializer)
       END IF
@@ -92,14 +92,14 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprec
     IF ( PRESENT(mode) ) ppser_mode = mode
     IF ( PRESENT(prefix_ref) ) THEN
       IF ( PRESENT(mpi_rank) ) THEN
-        IF ( PRESENT(opt_archive) ) THEN
-          CALL fs_create_serializer(directory, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref, opt_archive)
+        IF ( PRESENT(archive) ) THEN
+          CALL fs_create_serializer(directory, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref, archive)
         ELSE
           CALL fs_create_serializer(directory, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref)
         END IF
       ELSE
-        IF ( PRESENT(opt_archive) ) THEN
-          CALL fs_create_serializer(directory, TRIM(prefix_ref), 'r', ppser_serializer_ref, opt_archive)
+        IF ( PRESENT(archive) ) THEN
+          CALL fs_create_serializer(directory, TRIM(prefix_ref), 'r', ppser_serializer_ref, archive)
         ELSE
           CALL fs_create_serializer(directory, TRIM(prefix_ref), 'r', ppser_serializer_ref)
         END IF

--- a/src/serialbox-fortran/utils_ppser.f90
+++ b/src/serialbox-fortran/utils_ppser.f90
@@ -76,17 +76,33 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprec
   IF ( .NOT. ppser_initialized ) THEN
     IF ( PRESENT(mpi_rank) ) THEN
       WRITE(suffix, '(A5,I0)') "_rank", mpi_rank
-      CALL fs_create_serializer(directory, TRIM(prefix)//TRIM(suffix), 'w', ppser_serializer, opt_archive)
+      IF ( PRESENT(opt_archive) )
+        CALL fs_create_serializer(directory, TRIM(prefix)//TRIM(suffix), 'w', ppser_serializer, opt_archive)
+      ELSE
+        CALL fs_create_serializer(directory, TRIM(prefix)//TRIM(suffix), 'w', ppser_serializer)
+      END IF
     ELSE
-      CALL fs_create_serializer(directory, TRIM(prefix), 'w', ppser_serializer, opt_archive)
+      IF ( PRESENT(opt_archive) )
+        CALL fs_create_serializer(directory, TRIM(prefix), 'w', ppser_serializer, opt_archive)
+      ELSE
+        CALL fs_create_serializer(directory, TRIM(prefix), 'w', ppser_serializer)
+      END IF
     END IF
     CALL fs_create_savepoint('', ppser_savepoint)
     IF ( PRESENT(mode) ) ppser_mode = mode
     IF ( PRESENT(prefix_ref) ) THEN
       IF ( PRESENT(mpi_rank) ) THEN
-        CALL fs_create_serializer(directory, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref, opt_archive)
+        IF ( PRESENT(opt_archive) )
+          CALL fs_create_serializer(directory, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref, opt_archive)
+        ELSE
+          CALL fs_create_serializer(directory, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref)
+        END IF
       ELSE
-        CALL fs_create_serializer(directory, TRIM(prefix_ref), 'r', ppser_serializer_ref, opt_archive)
+        IF ( PRESENT(opt_archive) )
+          CALL fs_create_serializer(directory, TRIM(prefix_ref), 'r', ppser_serializer_ref, opt_archive)
+        ELSE
+          CALL fs_create_serializer(directory, TRIM(prefix_ref), 'r', ppser_serializer_ref)
+        END IF
       END IF
     END IF
   END IF


### PR DESCRIPTION
This item was missing after @chovyy 's fix. I named the parameter the same as in the called function, `opt_archive` which might not be the best name, because most parameters passed by pp_ser.py are optional. 

(This is my first ever public PR in Fortran ;-) ). 