### PR TITLE
Fix rank and strides computation in Fortran wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,8 @@ external/*
 
 # Ignore gh-pages folder
 gh-pages*
+
+#Ignore Eclipse files
 /.settings/
 /.cproject
+/.pydevproject

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ external/*
 
 # Ignore gh-pages folder
 gh-pages*
+/.settings/
+/.cproject

--- a/src/serialbox-c/FortranWrapper.cpp
+++ b/src/serialbox-c/FortranWrapper.cpp
@@ -133,20 +133,14 @@ void serialboxFortranComputeStrides(void* serializer, const char* fieldname, con
 
     const auto& dims = info.dims();
 
-    // Check rank
-    checkRank(fieldname, strides, dims);
-
     // Reorder strides
-    for(int i = 0; i < 4; ++i) {
-      if(dims[i] <= 1) {
-
-        // Shift strides to the left and set the current one to 0
-        for(int j = 3; j > i; --j)
-          strides[j] = strides[j - 1];
-
-        strides[i] = 0;
-      }
-    }
+    for (int i = 2; i >= 0; --i)
+	{
+		if (strides[i] == 0)
+		{
+			strides[i] = strides[i+1];
+		}
+	}
 
     // Convert to unit-strides
     const int bytesPerElement = serialbox::TypeUtil::sizeOf(info.type());

--- a/src/serialbox-c/FortranWrapper.cpp
+++ b/src/serialbox-c/FortranWrapper.cpp
@@ -60,7 +60,9 @@ static void checkRank(const char* name, ArrayType1&& array, ArrayType2&& arrayRe
   const int refRank = (arrayRef[0] > 0 ? 1 : 0) + (arrayRef[1] > 0 ? 1 : 0) +
                       (arrayRef[2] > 0 ? 1 : 0) + (arrayRef[3] > 0 ? 1 : 0);
 
-  if(rank != refRank)
+  bool scalar = rank == 0 && refRank == 1 && arrayRef[0] == 1;
+
+  if(rank != refRank && !scalar)
     throw Exception("field '%s' has rank %i but field with rank %i was passed", name, refRank,
                     rank);
 }

--- a/src/serialbox-c/FortranWrapper.cpp
+++ b/src/serialbox-c/FortranWrapper.cpp
@@ -131,16 +131,10 @@ void serialboxFortranComputeStrides(void* serializer, const char* fieldname, con
     if(info.dims().size() != 4)
       throw Exception("number of dimensions is %i, required are 4");
 
-    const auto& dims = info.dims();
-
     // Reorder strides
     for (int i = 2; i >= 0; --i)
-	{
 		if (strides[i] == 0)
-		{
 			strides[i] = strides[i+1];
-		}
-	}
 
     // Convert to unit-strides
     const int bytesPerElement = serialbox::TypeUtil::sizeOf(info.type());

--- a/src/serialbox-c/Serializer.cpp
+++ b/src/serialbox-c/Serializer.cpp
@@ -244,7 +244,7 @@ int serialboxSerializerAddField2(serialboxSerializer_t* serializer, const char* 
                                  bytesPerElement, typeName, serialbox::TypeUtil::sizeOf(typeID));
 
     int rank =
-        (iSize != 1 ? 1 : 0) + (jSize != 1 ? 1 : 0) + (kSize != 1 ? 1 : 0) + (lSize != 1 ? 1 : 0);
+        (iSize > 0 ? 1 : 0) + (jSize > 0 ? 1 : 0) + (kSize > 0 ? 1 : 0) + (lSize > 0 ? 1 : 0);
 
     std::vector<int> dims{iSize, jSize, kSize, lSize};
     MetainfoMap metaInfo;

--- a/test/serialbox-c/UnittestSerializer.cpp
+++ b/test/serialbox-c/UnittestSerializer.cpp
@@ -243,7 +243,7 @@ TEST_F(CSerializerUtilityTest, RegisterFields) {
 
   EXPECT_EQ(serialboxMetainfoGetInt32(metaInfo, "__bytesperelement"), 4);
   ASSERT_FALSE(this->hasErrorAndReset()) << this->getLastErrorMsg();
-  EXPECT_EQ(serialboxMetainfoGetInt32(metaInfo, "__rank"), 2);
+  EXPECT_EQ(serialboxMetainfoGetInt32(metaInfo, "__rank"), 4);
   ASSERT_FALSE(this->hasErrorAndReset()) << this->getLastErrorMsg();
 
   EXPECT_EQ(serialboxMetainfoGetInt32(metaInfo, "__isize"), 42);


### PR DESCRIPTION
This is my first change towards enabling Serialbox2 to be used with https://github.com/fortesg/fortrantestgenerator.

It tackles a general problem in the rank and strides computation in the C/Fortran wrapper when it comes to a) scalars and b) array dimensions with an actual size of 1.

You will find a test that fails with the current version under
https://github.com/chovyy/serialbox-pfunit/tree/rank
(I have already discussed with @havogt that this unit test for the Fortran interface shall be added to the test suite).

In the current version, when trying to write a scalar field, one will get an error like:
"field 'testfield_i0' has rank 1 but field with rank 0 was passed" and when writing an array with a one-sized dimension this dimension is counted in FortranWrapper::checkRank but not in Serializer::serialboxSerializerAddField2 which also leads to errors. 

The strides reordering in serialboxFortranComputeStrides was also broken, afais. The inline comment said "Shift strides to the left..." but it was actually shifted to the right. It also leads to problems with one-sized dimensions.

I have also removed the call to checkRank in serialboxFortranComputeStrides, since I can't see a) how the rank check based on the strides can be successful with scalars and one-sized dimensions and b) why a rank check is necessary at this point. I guess, it's enough to do that in serialboxFortranSerializerCheckField.

Cheers, Christian