### PR TITLE
[Fortran] Added read/write routines for LOGICAL and LOGICAL(KIND=C_BOOL)

### DIFF
--- a/src/serialbox-fortran/m_serialize.f90
+++ b/src/serialbox-fortran/m_serialize.f90
@@ -178,6 +178,11 @@ PRIVATE
   !------------------------------------------------------------------------------
   INTERFACE fs_write_field
     MODULE PROCEDURE &
+      fs_write_logical_0d, &
+      fs_write_logical_1d, &
+      fs_write_logical_2d, &
+      fs_write_logical_3d, &
+      fs_write_logical_4d, &
       fs_write_int_0d, &
       fs_write_int_1d, &
       fs_write_int_2d, &
@@ -201,6 +206,11 @@ PRIVATE
   !------------------------------------------------------------------------------
   INTERFACE fs_read_field
     MODULE PROCEDURE &
+      fs_read_logical_0d, &
+      fs_read_logical_1d, &
+      fs_read_logical_2d, &
+      fs_read_logical_3d, &
+      fs_read_logical_4d, &
       fs_read_int_0d, &
       fs_read_int_1d, &
       fs_read_int_2d, &
@@ -939,6 +949,140 @@ END SUBROUTINE fs_add_savepoint_metainfo_s
 !=============================================================================
 !=============================================================================
 
+SUBROUTINE fs_write_logical_0d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)          :: serializer
+  TYPE(t_savepoint) , INTENT(IN)          :: savepoint
+  CHARACTER(LEN=*)                        :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(IN), TARGET :: field
+
+  ! Local variables
+  INTEGER(C_INT) :: istride, jstride, kstride, lstride
+  LOGICAL(KIND=C_BOOL), POINTER :: padd
+
+  ! This workaround is needed for gcc < 4.9
+  padd=>field
+
+  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), 1, 0, 0, 0)
+  CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
+                       C_LOC(padd), C_LOC(padd), C_LOC(padd), C_LOC(padd), C_LOC(padd), &
+                       istride, jstride, kstride, lstride)
+  CALL fs_write_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
+                        TRIM(fieldname)//C_NULL_CHAR, &
+                       C_LOC(padd), istride, jstride, kstride, lstride)
+END SUBROUTINE fs_write_logical_0d
+
+
+SUBROUTINE fs_write_logical_1d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)          :: serializer
+  TYPE(t_savepoint) , INTENT(IN)          :: savepoint
+  CHARACTER(LEN=*)                        :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(IN), TARGET :: field(:)
+
+  ! Local variables
+  INTEGER(C_INT) :: istride, jstride, kstride, lstride
+  LOGICAL(KIND=C_BOOL), POINTER :: padd(:)
+
+  ! This workaround is needed for gcc < 4.9
+  padd=>field
+
+  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), 0, 0, 0)
+  CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
+                       C_LOC(padd(1)), &
+                       C_LOC(padd(MIN(2, SIZE(field, 1)))), &
+                       C_LOC(padd(1)), &
+                       C_LOC(padd(1)), &
+                       C_LOC(padd(1)), &
+                       istride, jstride, kstride, lstride)
+  CALL fs_write_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
+                        TRIM(fieldname)//C_NULL_CHAR, &
+                      C_LOC(padd(1)), istride, jstride, kstride, lstride)
+END SUBROUTINE fs_write_logical_1d
+
+
+SUBROUTINE fs_write_logical_2d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)          :: serializer
+  TYPE(t_savepoint) , INTENT(IN)          :: savepoint
+  CHARACTER(LEN=*)                        :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(IN), TARGET :: field(:,:)
+
+  ! Local variables
+  INTEGER(C_INT) :: istride, jstride, kstride, lstride
+  LOGICAL(KIND=C_BOOL), POINTER :: padd(:,:)
+
+  ! This workaround is needed for gcc < 4.9
+  padd=>field
+
+  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), SIZE(field, 2), 0, 0)
+  CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
+                       C_LOC(padd(1, 1)), &
+                       C_LOC(padd(MIN(2, SIZE(field, 1)), 1)), &
+                       C_LOC(padd(1, MIN(2, SIZE(field, 2)))), &
+                       C_LOC(padd(1, 1)), &
+                       C_LOC(padd(1, 1)), &
+                       istride, jstride, kstride, lstride)
+  CALL fs_write_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
+                        TRIM(fieldname)//C_NULL_CHAR, &
+                      C_LOC(padd(1,1)), istride, jstride, kstride, lstride)
+END SUBROUTINE fs_write_logical_2d
+
+
+SUBROUTINE fs_write_logical_3d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)          :: serializer
+  TYPE(t_savepoint) , INTENT(IN)          :: savepoint
+  CHARACTER(LEN=*)                        :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(IN), TARGET :: field(:,:,:)
+
+  ! Local variables
+  INTEGER(C_INT) :: istride, jstride, kstride, lstride
+  LOGICAL(KIND=C_BOOL), POINTER :: padd(:,:,:)
+
+  ! This workaround is needed for gcc < 4.9
+  padd=>field
+
+  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), SIZE(field, 2), SIZE(field, 3), 0)
+  CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
+                       C_LOC(padd(1, 1, 1)), &
+                       C_LOC(padd(MIN(2, SIZE(field, 1)), 1, 1)), &
+                       C_LOC(padd(1, MIN(2, SIZE(field, 2)), 1)), &
+                       C_LOC(padd(1, 1, MIN(2, SIZE(field, 3)))), &
+                       C_LOC(padd(1, 1, 1)), &
+                       istride, jstride, kstride, lstride)
+  CALL fs_write_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
+                        TRIM(fieldname)//C_NULL_CHAR, &
+                      C_LOC(padd(1,1,1)), istride, jstride, kstride, lstride)
+END SUBROUTINE fs_write_logical_3d
+
+
+SUBROUTINE fs_write_logical_4d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)          :: serializer
+  TYPE(t_savepoint) , INTENT(IN)          :: savepoint
+  CHARACTER(LEN=*)                        :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(IN), TARGET :: field(:,:,:,:)
+
+  ! Local variables
+  INTEGER(C_INT) :: istride, jstride, kstride, lstride
+  LOGICAL(KIND=C_BOOL), POINTER :: padd(:,:,:,:)
+
+  ! This workaround is needed for gcc < 4.9
+  padd=>field
+
+  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), SIZE(field, 2), &
+                                                                 SIZE(field, 3), SIZE(field, 4))
+  CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
+                       C_LOC(padd(1, 1, 1, 1)), &
+                       C_LOC(padd(MIN(2, SIZE(field, 1)), 1, 1, 1)), &
+                       C_LOC(padd(1, MIN(2, SIZE(field, 2)), 1, 1)), &
+                       C_LOC(padd(1, 1, MIN(2, SIZE(field, 3)), 1)), &
+                       C_LOC(padd(1, 1, 1, MIN(2, SIZE(field, 4)))), &
+                       istride, jstride, kstride, lstride)
+  CALL fs_write_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
+                        TRIM(fieldname)//C_NULL_CHAR, &
+                      C_LOC(padd(1,1,1,1)), istride, jstride, kstride, lstride)
+END SUBROUTINE fs_write_logical_4d
+
+!=============================================================================
+!=============================================================================
+
 SUBROUTINE fs_write_int_0d(serializer, savepoint, fieldname, field)
   TYPE(t_serializer), INTENT(IN)          :: serializer
   TYPE(t_savepoint) , INTENT(IN)          :: savepoint
@@ -1339,6 +1483,139 @@ SUBROUTINE fs_write_double_4d(serializer, savepoint, fieldname, field)
                         TRIM(fieldname)//C_NULL_CHAR, &
                       C_LOC(padd(1,1,1,1)), istride, jstride, kstride, lstride)
 END SUBROUTINE fs_write_double_4d
+
+!=============================================================================
+!=============================================================================
+
+SUBROUTINE fs_read_logical_0d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)           :: serializer
+  TYPE(t_savepoint) , INTENT(IN)           :: savepoint
+  CHARACTER(LEN=*)                         :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(OUT), TARGET :: field
+
+  ! Local variables
+  INTEGER(C_INT) :: istride, jstride, kstride, lstride
+  LOGICAL(KIND=C_BOOL), POINTER :: padd
+
+  ! This workaround is needed for gcc < 4.9
+  padd=>field
+
+  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), 0, 0, 0, 0)
+  CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
+                       C_LOC(padd), C_LOC(padd), C_LOC(padd), C_LOC(padd), C_LOC(padd), &
+                       istride, jstride, kstride, lstride)
+  CALL fs_read_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
+                      TRIM(fieldname)//C_NULL_CHAR, &
+                      C_LOC(padd), istride, jstride, kstride, lstride)
+END SUBROUTINE fs_read_logical_0d
+
+
+SUBROUTINE fs_read_logical_1d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)           :: serializer
+  TYPE(t_savepoint) , INTENT(IN)           :: savepoint
+  CHARACTER(LEN=*)                         :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(OUT), TARGET :: field(:)
+
+  ! Local variables
+  INTEGER(C_INT) :: istride, jstride, kstride, lstride
+  LOGICAL(KIND=C_BOOL), POINTER :: padd(:)
+
+  ! This workaround is needed for gcc < 4.9
+  padd=>field
+
+  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), 0, 0, 0)
+  CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
+                       C_LOC(padd(1)), &
+                       C_LOC(padd(MIN(2, SIZE(field, 1)))), &
+                       C_LOC(padd(1)), &
+                       C_LOC(padd(1)), &
+                       C_LOC(padd(1)), &
+                       istride, jstride, kstride, lstride)
+  CALL fs_read_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
+                       TRIM(fieldname)//C_NULL_CHAR, &
+                      C_LOC(padd(1)), istride, jstride, kstride, lstride)
+END SUBROUTINE fs_read_logical_1d
+
+
+SUBROUTINE fs_read_logical_2d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)           :: serializer
+  TYPE(t_savepoint) , INTENT(IN)           :: savepoint
+  CHARACTER(LEN=*)                         :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(OUT), TARGET :: field(:,:)
+
+  ! Local variables
+  INTEGER(C_INT) :: istride, jstride, kstride, lstride
+  LOGICAL(KIND=C_BOOL), POINTER :: padd(:,:)
+
+  ! This workaround is needed for gcc < 4.9
+  padd=>field
+
+  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), SIZE(field, 2), 0, 0)
+  CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
+                       C_LOC(padd(1, 1)), &
+                       C_LOC(padd(MIN(2, SIZE(field, 1)), 1)), &
+                       C_LOC(padd(1, MIN(2, SIZE(field, 2)))), &
+                       C_LOC(padd(1, 1)), &
+                       C_LOC(padd(1, 1)), &
+                       istride, jstride, kstride, lstride)
+  CALL fs_read_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
+                       TRIM(fieldname)//C_NULL_CHAR, &
+                      C_LOC(padd(1,1)), istride, jstride, kstride, lstride)
+END SUBROUTINE fs_read_logical_2d
+
+
+SUBROUTINE fs_read_logical_3d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)           :: serializer
+  TYPE(t_savepoint) , INTENT(IN)           :: savepoint
+  CHARACTER(LEN=*)                         :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(OUT), TARGET :: field(:,:,:)
+
+  ! Local variables
+  INTEGER(C_INT) :: istride, jstride, kstride, lstride
+  LOGICAL(KIND=C_BOOL), POINTER :: padd(:,:,:)
+
+  ! This workaround is needed for gcc < 4.9
+  padd=>field
+
+  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), SIZE(field, 2), SIZE(field, 3), 0)
+  CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
+                       C_LOC(padd(1, 1, 1)), &
+                       C_LOC(padd(MIN(2, SIZE(field, 1)), 1, 1)), &
+                       C_LOC(padd(1, MIN(2, SIZE(field, 2)), 1)), &
+                       C_LOC(padd(1, 1, MIN(2, SIZE(field, 3)))), &
+                       C_LOC(padd(1, 1, 1)), &
+                       istride, jstride, kstride, lstride)
+  CALL fs_read_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
+                       TRIM(fieldname)//C_NULL_CHAR, &
+                      C_LOC(padd(1,1,1)), istride, jstride, kstride, lstride)
+END SUBROUTINE fs_read_logical_3d
+
+SUBROUTINE fs_read_logical_4d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)           :: serializer
+  TYPE(t_savepoint) , INTENT(IN)           :: savepoint
+  CHARACTER(LEN=*)                         :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(OUT), TARGET :: field(:,:,:,:)
+
+  ! Local variables
+  INTEGER(C_INT) :: istride, jstride, kstride, lstride
+  LOGICAL(KIND=C_BOOL), POINTER :: padd(:,:,:,:)
+
+  ! This workaround is needed for gcc < 4.9
+  padd=>field
+
+  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), SIZE(field, 2), &
+                                                      SIZE(field, 3), SIZE(field, 4))
+  CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
+                       C_LOC(padd(1, 1, 1, 1)), &
+                       C_LOC(padd(MIN(2, SIZE(field, 1)), 1, 1, 1)), &
+                       C_LOC(padd(1, MIN(2, SIZE(field, 2)), 1, 1)), &
+                       C_LOC(padd(1, 1, MIN(2, SIZE(field, 3)), 1)), &
+                       C_LOC(padd(1, 1, 1, MIN(2, SIZE(field, 4)))), &
+                       istride, jstride, kstride, lstride)
+  CALL fs_read_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
+                       TRIM(fieldname)//C_NULL_CHAR, &
+                      C_LOC(padd(1,1,1,1)), istride, jstride, kstride, lstride)
+END SUBROUTINE fs_read_logical_4d
 
 !=============================================================================
 !=============================================================================

--- a/src/serialbox-fortran/m_serialize.f90
+++ b/src/serialbox-fortran/m_serialize.f90
@@ -183,6 +183,11 @@ PRIVATE
       fs_write_logical_2d, &
       fs_write_logical_3d, &
       fs_write_logical_4d, &
+      fs_write_bool_0d, &
+      fs_write_bool_1d, &
+      fs_write_bool_2d, &
+      fs_write_bool_3d, &
+      fs_write_bool_4d, &
       fs_write_int_0d, &
       fs_write_int_1d, &
       fs_write_int_2d, &
@@ -211,6 +216,11 @@ PRIVATE
       fs_read_logical_2d, &
       fs_read_logical_3d, &
       fs_read_logical_4d, &
+      fs_read_bool_0d, &
+      fs_read_bool_1d, &
+      fs_read_bool_2d, &
+      fs_read_bool_3d, &
+      fs_read_bool_4d, &
       fs_read_int_0d, &
       fs_read_int_1d, &
       fs_read_int_2d, &
@@ -953,6 +963,87 @@ SUBROUTINE fs_write_logical_0d(serializer, savepoint, fieldname, field)
   TYPE(t_serializer), INTENT(IN)          :: serializer
   TYPE(t_savepoint) , INTENT(IN)          :: savepoint
   CHARACTER(LEN=*)                        :: fieldname
+  LOGICAL, INTENT(IN), TARGET :: field
+
+  ! Local variables
+  LOGICAL(KIND=C_BOOL) :: bool
+
+  bool = field .EQV. .TRUE.
+  CALL fs_write_field(serializer, savepoint, fieldname, bool)
+
+END SUBROUTINE fs_write_logical_0d
+
+
+SUBROUTINE fs_write_logical_1d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)          :: serializer
+  TYPE(t_savepoint) , INTENT(IN)          :: savepoint
+  CHARACTER(LEN=*)                        :: fieldname
+  LOGICAL, INTENT(IN), TARGET :: field(:)
+
+  ! Local variables
+  LOGICAL(KIND=C_BOOL), ALLOCATABLE :: bool(:)
+
+  ALLOCATE(bool(SIZE(field, 1)))
+  bool = field
+  CALL fs_write_field(serializer, savepoint, fieldname, bool)
+
+END SUBROUTINE fs_write_logical_1d
+
+
+SUBROUTINE fs_write_logical_2d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)          :: serializer
+  TYPE(t_savepoint) , INTENT(IN)          :: savepoint
+  CHARACTER(LEN=*)                        :: fieldname
+  LOGICAL, INTENT(IN), TARGET :: field(:,:)
+
+  ! Local variables
+  LOGICAL(KIND=C_BOOL), ALLOCATABLE :: bool(:,:)
+
+  ALLOCATE(bool(SIZE(field, 1), SIZE(field, 2)))
+  bool = field
+  CALL fs_write_field(serializer, savepoint, fieldname, bool)
+
+END SUBROUTINE fs_write_logical_2d
+
+
+SUBROUTINE fs_write_logical_3d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)          :: serializer
+  TYPE(t_savepoint) , INTENT(IN)          :: savepoint
+  CHARACTER(LEN=*)                        :: fieldname
+  LOGICAL, INTENT(IN), TARGET :: field(:,:,:)
+
+  ! Local variables
+  LOGICAL(KIND=C_BOOL), ALLOCATABLE :: bool(:,:,:)
+
+  ALLOCATE(bool(SIZE(field, 1), SIZE(field, 2), SIZE(field, 3)))
+  bool = field
+  CALL fs_write_field(serializer, savepoint, fieldname, bool)
+
+END SUBROUTINE fs_write_logical_3d
+
+
+SUBROUTINE fs_write_logical_4d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)          :: serializer
+  TYPE(t_savepoint) , INTENT(IN)          :: savepoint
+  CHARACTER(LEN=*)                        :: fieldname
+  LOGICAL, INTENT(IN), TARGET :: field(:,:,:,:)
+
+  ! Local variables
+  LOGICAL(KIND=C_BOOL), ALLOCATABLE :: bool(:,:,:,:)
+
+  ALLOCATE(bool(SIZE(field, 1), SIZE(field, 2), SIZE(field, 3), SIZE(field, 4)))
+  bool = field
+  CALL fs_write_field(serializer, savepoint, fieldname, bool)
+
+END SUBROUTINE fs_write_logical_4d
+
+!=============================================================================
+!=============================================================================
+
+SUBROUTINE fs_write_bool_0d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)          :: serializer
+  TYPE(t_savepoint) , INTENT(IN)          :: savepoint
+  CHARACTER(LEN=*)                        :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(IN), TARGET :: field
 
   ! Local variables
@@ -969,10 +1060,10 @@ SUBROUTINE fs_write_logical_0d(serializer, savepoint, fieldname, field)
   CALL fs_write_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
                         TRIM(fieldname)//C_NULL_CHAR, &
                        C_LOC(padd), istride, jstride, kstride, lstride)
-END SUBROUTINE fs_write_logical_0d
+END SUBROUTINE fs_write_bool_0d
 
 
-SUBROUTINE fs_write_logical_1d(serializer, savepoint, fieldname, field)
+SUBROUTINE fs_write_bool_1d(serializer, savepoint, fieldname, field)
   TYPE(t_serializer), INTENT(IN)          :: serializer
   TYPE(t_savepoint) , INTENT(IN)          :: savepoint
   CHARACTER(LEN=*)                        :: fieldname
@@ -996,10 +1087,10 @@ SUBROUTINE fs_write_logical_1d(serializer, savepoint, fieldname, field)
   CALL fs_write_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
                         TRIM(fieldname)//C_NULL_CHAR, &
                       C_LOC(padd(1)), istride, jstride, kstride, lstride)
-END SUBROUTINE fs_write_logical_1d
+END SUBROUTINE fs_write_bool_1d
 
 
-SUBROUTINE fs_write_logical_2d(serializer, savepoint, fieldname, field)
+SUBROUTINE fs_write_bool_2d(serializer, savepoint, fieldname, field)
   TYPE(t_serializer), INTENT(IN)          :: serializer
   TYPE(t_savepoint) , INTENT(IN)          :: savepoint
   CHARACTER(LEN=*)                        :: fieldname
@@ -1023,10 +1114,10 @@ SUBROUTINE fs_write_logical_2d(serializer, savepoint, fieldname, field)
   CALL fs_write_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
                         TRIM(fieldname)//C_NULL_CHAR, &
                       C_LOC(padd(1,1)), istride, jstride, kstride, lstride)
-END SUBROUTINE fs_write_logical_2d
+END SUBROUTINE fs_write_bool_2d
 
 
-SUBROUTINE fs_write_logical_3d(serializer, savepoint, fieldname, field)
+SUBROUTINE fs_write_bool_3d(serializer, savepoint, fieldname, field)
   TYPE(t_serializer), INTENT(IN)          :: serializer
   TYPE(t_savepoint) , INTENT(IN)          :: savepoint
   CHARACTER(LEN=*)                        :: fieldname
@@ -1050,10 +1141,10 @@ SUBROUTINE fs_write_logical_3d(serializer, savepoint, fieldname, field)
   CALL fs_write_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
                         TRIM(fieldname)//C_NULL_CHAR, &
                       C_LOC(padd(1,1,1)), istride, jstride, kstride, lstride)
-END SUBROUTINE fs_write_logical_3d
+END SUBROUTINE fs_write_bool_3d
 
 
-SUBROUTINE fs_write_logical_4d(serializer, savepoint, fieldname, field)
+SUBROUTINE fs_write_bool_4d(serializer, savepoint, fieldname, field)
   TYPE(t_serializer), INTENT(IN)          :: serializer
   TYPE(t_savepoint) , INTENT(IN)          :: savepoint
   CHARACTER(LEN=*)                        :: fieldname
@@ -1078,7 +1169,7 @@ SUBROUTINE fs_write_logical_4d(serializer, savepoint, fieldname, field)
   CALL fs_write_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
                         TRIM(fieldname)//C_NULL_CHAR, &
                       C_LOC(padd(1,1,1,1)), istride, jstride, kstride, lstride)
-END SUBROUTINE fs_write_logical_4d
+END SUBROUTINE fs_write_bool_4d
 
 !=============================================================================
 !=============================================================================
@@ -1491,6 +1582,86 @@ SUBROUTINE fs_read_logical_0d(serializer, savepoint, fieldname, field)
   TYPE(t_serializer), INTENT(IN)           :: serializer
   TYPE(t_savepoint) , INTENT(IN)           :: savepoint
   CHARACTER(LEN=*)                         :: fieldname
+  LOGICAL, INTENT(OUT), TARGET :: field
+
+  ! Local variables
+  LOGICAL(KIND=C_BOOL) :: bool
+
+  CALL fs_read_field(serializer, savepoint, fieldname, bool)
+  field = bool
+
+END SUBROUTINE fs_read_logical_0d
+
+
+SUBROUTINE fs_read_logical_1d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)           :: serializer
+  TYPE(t_savepoint) , INTENT(IN)           :: savepoint
+  CHARACTER(LEN=*)                         :: fieldname
+  LOGICAL, INTENT(OUT), TARGET :: field(:)
+
+  ! Local variables
+  LOGICAL(KIND=C_BOOL), ALLOCATABLE :: bool(:)
+
+  ALLOCATE(bool(SIZE(field, 1)))
+  CALL fs_read_field(serializer, savepoint, fieldname, bool)
+  field = bool
+
+END SUBROUTINE fs_read_logical_1d
+
+
+SUBROUTINE fs_read_logical_2d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)           :: serializer
+  TYPE(t_savepoint) , INTENT(IN)           :: savepoint
+  CHARACTER(LEN=*)                         :: fieldname
+  LOGICAL, INTENT(OUT), TARGET :: field(:,:)
+
+  ! Local variables
+  LOGICAL(KIND=C_BOOL), ALLOCATABLE :: bool(:,:)
+
+  ALLOCATE(bool(SIZE(field, 1), SIZE(field, 2)))
+  CALL fs_read_field(serializer, savepoint, fieldname, bool)
+  field = bool
+
+END SUBROUTINE fs_read_logical_2d
+
+
+SUBROUTINE fs_read_logical_3d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)           :: serializer
+  TYPE(t_savepoint) , INTENT(IN)           :: savepoint
+  CHARACTER(LEN=*)                         :: fieldname
+  LOGICAL, INTENT(OUT), TARGET :: field(:,:,:)
+
+  ! Local variables
+  LOGICAL(KIND=C_BOOL), ALLOCATABLE :: bool(:,:,:)
+
+  ALLOCATE(bool(SIZE(field, 1), SIZE(field, 2), SIZE(field, 3)))
+  CALL fs_read_field(serializer, savepoint, fieldname, bool)
+  field = bool
+
+END SUBROUTINE fs_read_logical_3d
+
+SUBROUTINE fs_read_logical_4d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)           :: serializer
+  TYPE(t_savepoint) , INTENT(IN)           :: savepoint
+  CHARACTER(LEN=*)                         :: fieldname
+  LOGICAL, INTENT(OUT), TARGET :: field(:,:,:,:)
+
+  ! Local variables
+  LOGICAL(KIND=C_BOOL), ALLOCATABLE :: bool(:,:,:,:)
+
+  ALLOCATE(bool(SIZE(field, 1), SIZE(field, 2), SIZE(field, 3), SIZE(field, 4)))
+  CALL fs_read_field(serializer, savepoint, fieldname, bool)
+  field = bool
+
+END SUBROUTINE fs_read_logical_4d
+
+!=============================================================================
+!=============================================================================
+
+SUBROUTINE fs_read_bool_0d(serializer, savepoint, fieldname, field)
+  TYPE(t_serializer), INTENT(IN)           :: serializer
+  TYPE(t_savepoint) , INTENT(IN)           :: savepoint
+  CHARACTER(LEN=*)                         :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), TARGET :: field
 
   ! Local variables
@@ -1507,10 +1678,10 @@ SUBROUTINE fs_read_logical_0d(serializer, savepoint, fieldname, field)
   CALL fs_read_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
                       TRIM(fieldname)//C_NULL_CHAR, &
                       C_LOC(padd), istride, jstride, kstride, lstride)
-END SUBROUTINE fs_read_logical_0d
+END SUBROUTINE fs_read_bool_0d
 
 
-SUBROUTINE fs_read_logical_1d(serializer, savepoint, fieldname, field)
+SUBROUTINE fs_read_bool_1d(serializer, savepoint, fieldname, field)
   TYPE(t_serializer), INTENT(IN)           :: serializer
   TYPE(t_savepoint) , INTENT(IN)           :: savepoint
   CHARACTER(LEN=*)                         :: fieldname
@@ -1534,10 +1705,10 @@ SUBROUTINE fs_read_logical_1d(serializer, savepoint, fieldname, field)
   CALL fs_read_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
                        TRIM(fieldname)//C_NULL_CHAR, &
                       C_LOC(padd(1)), istride, jstride, kstride, lstride)
-END SUBROUTINE fs_read_logical_1d
+END SUBROUTINE fs_read_bool_1d
 
 
-SUBROUTINE fs_read_logical_2d(serializer, savepoint, fieldname, field)
+SUBROUTINE fs_read_bool_2d(serializer, savepoint, fieldname, field)
   TYPE(t_serializer), INTENT(IN)           :: serializer
   TYPE(t_savepoint) , INTENT(IN)           :: savepoint
   CHARACTER(LEN=*)                         :: fieldname
@@ -1561,10 +1732,10 @@ SUBROUTINE fs_read_logical_2d(serializer, savepoint, fieldname, field)
   CALL fs_read_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
                        TRIM(fieldname)//C_NULL_CHAR, &
                       C_LOC(padd(1,1)), istride, jstride, kstride, lstride)
-END SUBROUTINE fs_read_logical_2d
+END SUBROUTINE fs_read_bool_2d
 
 
-SUBROUTINE fs_read_logical_3d(serializer, savepoint, fieldname, field)
+SUBROUTINE fs_read_bool_3d(serializer, savepoint, fieldname, field)
   TYPE(t_serializer), INTENT(IN)           :: serializer
   TYPE(t_savepoint) , INTENT(IN)           :: savepoint
   CHARACTER(LEN=*)                         :: fieldname
@@ -1588,9 +1759,9 @@ SUBROUTINE fs_read_logical_3d(serializer, savepoint, fieldname, field)
   CALL fs_read_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
                        TRIM(fieldname)//C_NULL_CHAR, &
                       C_LOC(padd(1,1,1)), istride, jstride, kstride, lstride)
-END SUBROUTINE fs_read_logical_3d
+END SUBROUTINE fs_read_bool_3d
 
-SUBROUTINE fs_read_logical_4d(serializer, savepoint, fieldname, field)
+SUBROUTINE fs_read_bool_4d(serializer, savepoint, fieldname, field)
   TYPE(t_serializer), INTENT(IN)           :: serializer
   TYPE(t_savepoint) , INTENT(IN)           :: savepoint
   CHARACTER(LEN=*)                         :: fieldname
@@ -1615,7 +1786,7 @@ SUBROUTINE fs_read_logical_4d(serializer, savepoint, fieldname, field)
   CALL fs_read_field_(serializer%serializer_ptr, savepoint%savepoint_ptr, &
                        TRIM(fieldname)//C_NULL_CHAR, &
                       C_LOC(padd(1,1,1,1)), istride, jstride, kstride, lstride)
-END SUBROUTINE fs_read_logical_4d
+END SUBROUTINE fs_read_bool_4d
 
 !=============================================================================
 !=============================================================================

--- a/src/serialbox-fortran/m_serialize.f90
+++ b/src/serialbox-fortran/m_serialize.f90
@@ -264,6 +264,15 @@ CONTAINS
 
 !============================================================================
 
+FUNCTION fs_boolsize()
+  INTEGER(KIND=C_INT) :: fs_boolsize
+
+  CHARACTER(LEN=1), DIMENSION(128) :: buffer
+  LOGICAL(KIND=C_BOOL) :: boolvalue
+
+  fs_boolsize = INT(SIZE(TRANSFER(boolvalue, buffer)))
+END FUNCTION fs_boolsize
+
 FUNCTION fs_intsize()
   INTEGER(KIND=C_INT) :: fs_intsize
 
@@ -968,7 +977,7 @@ SUBROUTINE fs_write_logical_0d(serializer, savepoint, fieldname, field)
   ! Local variables
   LOGICAL(KIND=C_BOOL) :: bool
 
-  bool = field .EQV. .TRUE.
+  bool = field
   CALL fs_write_field(serializer, savepoint, fieldname, bool)
 
 END SUBROUTINE fs_write_logical_0d
@@ -1053,7 +1062,7 @@ SUBROUTINE fs_write_bool_0d(serializer, savepoint, fieldname, field)
   ! This workaround is needed for gcc < 4.9
   padd=>field
 
-  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), 1, 0, 0, 0)
+  CALL fs_check_size(serializer, fieldname, "bool", fs_boolsize(), 1, 0, 0, 0)
   CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
                        C_LOC(padd), C_LOC(padd), C_LOC(padd), C_LOC(padd), C_LOC(padd), &
                        istride, jstride, kstride, lstride)
@@ -1076,7 +1085,7 @@ SUBROUTINE fs_write_bool_1d(serializer, savepoint, fieldname, field)
   ! This workaround is needed for gcc < 4.9
   padd=>field
 
-  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), 0, 0, 0)
+  CALL fs_check_size(serializer, fieldname, "bool", fs_boolsize(), SIZE(field, 1), 0, 0, 0)
   CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
                        C_LOC(padd(1)), &
                        C_LOC(padd(MIN(2, SIZE(field, 1)))), &
@@ -1103,7 +1112,7 @@ SUBROUTINE fs_write_bool_2d(serializer, savepoint, fieldname, field)
   ! This workaround is needed for gcc < 4.9
   padd=>field
 
-  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), SIZE(field, 2), 0, 0)
+  CALL fs_check_size(serializer, fieldname, "bool", fs_boolsize(), SIZE(field, 1), SIZE(field, 2), 0, 0)
   CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
                        C_LOC(padd(1, 1)), &
                        C_LOC(padd(MIN(2, SIZE(field, 1)), 1)), &
@@ -1130,7 +1139,7 @@ SUBROUTINE fs_write_bool_3d(serializer, savepoint, fieldname, field)
   ! This workaround is needed for gcc < 4.9
   padd=>field
 
-  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), SIZE(field, 2), SIZE(field, 3), 0)
+  CALL fs_check_size(serializer, fieldname, "bool", fs_boolsize(), SIZE(field, 1), SIZE(field, 2), SIZE(field, 3), 0)
   CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
                        C_LOC(padd(1, 1, 1)), &
                        C_LOC(padd(MIN(2, SIZE(field, 1)), 1, 1)), &
@@ -1157,7 +1166,7 @@ SUBROUTINE fs_write_bool_4d(serializer, savepoint, fieldname, field)
   ! This workaround is needed for gcc < 4.9
   padd=>field
 
-  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), SIZE(field, 2), &
+  CALL fs_check_size(serializer, fieldname, "bool", fs_boolsize(), SIZE(field, 1), SIZE(field, 2), &
                                                                  SIZE(field, 3), SIZE(field, 4))
   CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
                        C_LOC(padd(1, 1, 1, 1)), &
@@ -1671,7 +1680,7 @@ SUBROUTINE fs_read_bool_0d(serializer, savepoint, fieldname, field)
   ! This workaround is needed for gcc < 4.9
   padd=>field
 
-  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), 0, 0, 0, 0)
+  CALL fs_check_size(serializer, fieldname, "bool", fs_boolsize(), 0, 0, 0, 0)
   CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
                        C_LOC(padd), C_LOC(padd), C_LOC(padd), C_LOC(padd), C_LOC(padd), &
                        istride, jstride, kstride, lstride)
@@ -1694,7 +1703,7 @@ SUBROUTINE fs_read_bool_1d(serializer, savepoint, fieldname, field)
   ! This workaround is needed for gcc < 4.9
   padd=>field
 
-  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), 0, 0, 0)
+  CALL fs_check_size(serializer, fieldname, "bool", fs_boolsize(), SIZE(field, 1), 0, 0, 0)
   CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
                        C_LOC(padd(1)), &
                        C_LOC(padd(MIN(2, SIZE(field, 1)))), &
@@ -1721,7 +1730,7 @@ SUBROUTINE fs_read_bool_2d(serializer, savepoint, fieldname, field)
   ! This workaround is needed for gcc < 4.9
   padd=>field
 
-  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), SIZE(field, 2), 0, 0)
+  CALL fs_check_size(serializer, fieldname, "bool", fs_boolsize(), SIZE(field, 1), SIZE(field, 2), 0, 0)
   CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
                        C_LOC(padd(1, 1)), &
                        C_LOC(padd(MIN(2, SIZE(field, 1)), 1)), &
@@ -1748,7 +1757,7 @@ SUBROUTINE fs_read_bool_3d(serializer, savepoint, fieldname, field)
   ! This workaround is needed for gcc < 4.9
   padd=>field
 
-  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), SIZE(field, 2), SIZE(field, 3), 0)
+  CALL fs_check_size(serializer, fieldname, "bool", fs_boolsize(), SIZE(field, 1), SIZE(field, 2), SIZE(field, 3), 0)
   CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
                        C_LOC(padd(1, 1, 1)), &
                        C_LOC(padd(MIN(2, SIZE(field, 1)), 1, 1)), &
@@ -1774,7 +1783,7 @@ SUBROUTINE fs_read_bool_4d(serializer, savepoint, fieldname, field)
   ! This workaround is needed for gcc < 4.9
   padd=>field
 
-  CALL fs_check_size(serializer, fieldname, "bool", fs_intsize(), SIZE(field, 1), SIZE(field, 2), &
+  CALL fs_check_size(serializer, fieldname, "bool", fs_boolsize(), SIZE(field, 1), SIZE(field, 2), &
                                                       SIZE(field, 3), SIZE(field, 4))
   CALL fs_compute_strides(serializer%serializer_ptr,  TRIM(fieldname)//C_NULL_CHAR, &
                        C_LOC(padd(1, 1, 1, 1)), &

--- a/test/serialbox-fortran/serialbox_test.pf
+++ b/test/serialbox-fortran/serialbox_test.pf
@@ -126,6 +126,8 @@ CONTAINS
       CALL fs_create_serializer(dir, base_name, 'w', serializer)
       CALL fs_write_field(serializer, savepoint, "testfield_i0", w_testfield_i0)
       CALL fs_write_field(serializer, savepoint, "testfield_i1", w_testfield_i1)
+      CALL fs_write_field(serializer, savepoint, "testfield_l0", w_testfield_l0)
+      CALL fs_write_field(serializer, savepoint, "testfield_l1", w_testfield_l1)
       CALL fs_destroy_serializer(serializer)
       
       CALL fs_create_serializer(dir, base_name, 'r', serializer)

--- a/test/serialbox-fortran/serialbox_test.pf
+++ b/test/serialbox-fortran/serialbox_test.pf
@@ -69,16 +69,59 @@ CONTAINS
     END SUBROUTINE testIntegerArrays
    
 @Test
+    SUBROUTINE testLogicalArrays()
+    
+      TYPE(t_serializer) :: serializer
+      LOGICAL :: w_testfield_l1(5), w_testfield_l2(4,3), w_testfield_l3(3,2,2), w_testfield_l4(2,2,2,2)
+      LOGICAL :: r_testfield_l1(5), r_testfield_l2(4,3), r_testfield_l3(3,2,2), r_testfield_l4(2,2,2,2)
+      
+      CHARACTER(len=*), PARAMETER :: base_name = 'test_logical'
+      
+      w_testfield_l1 = (/ .TRUE., .FALSE., .FALSE., .TRUE., .FALSE. /)
+      w_testfield_l2 = RESHAPE((/ .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE. /), SHAPE(w_testfield_l2))
+      w_testfield_l3 = RESHAPE((/ .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE. /), SHAPE(w_testfield_l3))
+      w_testfield_l4 = RESHAPE((/ .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE. /), SHAPE(w_testfield_l4))
+!            
+!      CALL fs_create_serializer(dir, base_name, 'w', serializer)
+!      CALL fs_write_field(serializer, savepoint, "testfield_l1", w_testfield_l1)
+!      CALL fs_write_field(serializer, savepoint, "testfield_l2", w_testfield_l2)
+!      CALL fs_write_field(serializer, savepoint, "testfield_l3", w_testfield_l3)
+!      CALL fs_write_field(serializer, savepoint, "testfield_l4", w_testfield_l4)
+!      CALL fs_destroy_serializer(serializer)
+!      
+!      CALL fs_create_serializer(dir, base_name, 'r', serializer)
+!      @assertTrue(fs_field_exists(serializer, "testfield_l1"))
+!      @assertTrue(fs_field_exists(serializer, "testfield_l2"))
+!      @assertTrue(fs_field_exists(serializer, "testfield_l3"))
+!      @assertTrue(fs_field_exists(serializer, "testfield_l4"))
+!      CALL fs_read_field(serializer, savepoint, "testfield_l1", r_testfield_l1)
+!      CALL fs_read_field(serializer, savepoint, "testfield_l2", r_testfield_l2)
+!      CALL fs_read_field(serializer, savepoint, "testfield_l3", r_testfield_l3)
+!      CALL fs_read_field(serializer, savepoint, "testfield_l4", r_testfield_l4)
+!      CALL fs_destroy_serializer(serializer)
+!      
+!      @assertEqual(w_testfield_l1, r_testfield_l1)
+!      @assertEqual(w_testfield_l2, r_testfield_l2)
+!      @assertEqual(w_testfield_l3, r_testfield_l3)
+!      @assertEqual(w_testfield_l4, r_testfield_l4)
+    
+    END SUBROUTINE testLogicalArrays
+   
+@Test
     SUBROUTINE testScalars()
     
       TYPE(t_serializer) :: serializer
       INTEGER :: w_testfield_i0, r_testfield_i0
       INTEGER :: w_testfield_i1(1), r_testfield_i1(1), w_testfield_i1_size(1), w_testfield_i1_bounds(2)
+      INTEGER :: w_testfield_l0, r_testfield_l0
+      INTEGER :: w_testfield_l1(1), r_testfield_l1(1), w_testfield_l1_size(1), w_testfield_l1_bounds(2)
       
       CHARACTER(len=*), PARAMETER :: base_name = 'test_scalars'
       
       w_testfield_i0 = 42
       w_testfield_i1 = (/ 999 /)
+      w_testfield_l0 = .TRUE.
+      w_testfield_l1 = (/ .FALSE. /)
             
       CALL fs_create_serializer(dir, base_name, 'w', serializer)
       CALL fs_write_field(serializer, savepoint, "testfield_i0", w_testfield_i0)
@@ -90,16 +133,26 @@ CONTAINS
       @assertTrue(fs_field_exists(serializer, "testfield_i0"))
       
       @assertTrue(fs_field_exists(serializer, "testfield_i1"))
-      !@assertEqual(w_testfield_i1a_size, fs_get_field_size(serializer, "testfield_i1a_rank"))
-      !@assertEqual(w_testfield_i1a_bounds, fs_get_field_bounds(serializer, "testfield_i1a_rank"))
+      !@assertEqual(w_testfield_i1a_size, fs_get_field_size(serializer, "testfield_i1"))
+      !@assertEqual(w_testfield_i1a_bounds, fs_get_field_bounds(serializer, "testfield_i1"))
+      
+      @assertTrue(fs_field_exists(serializer, "testfield_l0"))
+      
+      @assertTrue(fs_field_exists(serializer, "testfield_l1"))
+      !@assertEqual(w_testfield_l1a_size, fs_get_field_size(serializer, "testfield_l1"))
+      !@assertEqual(w_testfield_l1a_bounds, fs_get_field_bounds(serializer, "testfield_l1"))
       
       CALL fs_read_field(serializer, savepoint, "testfield_i0", r_testfield_i0)
       CALL fs_read_field(serializer, savepoint, "testfield_i1", r_testfield_i1)
+      CALL fs_read_field(serializer, savepoint, "testfield_l0", r_testfield_l0)
+      CALL fs_read_field(serializer, savepoint, "testfield_l1", r_testfield_l1)
       
       CALL fs_destroy_serializer(serializer)
       
       @assertEqual(w_testfield_i0, r_testfield_i0)
       @assertEqual(w_testfield_i1, r_testfield_i1)
+      @assertEqual(w_testfield_l0, r_testfield_l0)
+      @assertEqual(w_testfield_l1, r_testfield_l1)
     
     END SUBROUTINE testScalars
    

--- a/test/serialbox-fortran/serialbox_test.pf
+++ b/test/serialbox-fortran/serialbox_test.pf
@@ -74,6 +74,8 @@ CONTAINS
       TYPE(t_serializer) :: serializer
       LOGICAL :: w_testfield_l1(5), w_testfield_l2(4,3), w_testfield_l3(3,2,2), w_testfield_l4(2,2,2,2)
       LOGICAL :: r_testfield_l1(5), r_testfield_l2(4,3), r_testfield_l3(3,2,2), r_testfield_l4(2,2,2,2)
+      INTEGER :: w_testfield_i2(4,3), w_testfield_i3(3,2,2), w_testfield_i4(2,2,2,2)
+      INTEGER :: r_testfield_i2(4,3), r_testfield_i3(3,2,2), r_testfield_i4(2,2,2,2)
       
       CHARACTER(len=*), PARAMETER :: base_name = 'test_logical'
       
@@ -82,28 +84,36 @@ CONTAINS
       w_testfield_l3 = RESHAPE((/ .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE. /), SHAPE(w_testfield_l3))
       w_testfield_l4 = RESHAPE((/ .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE. /), SHAPE(w_testfield_l4))
             
-!      CALL fs_create_serializer(dir, base_name, 'w', serializer)
-!      CALL fs_write_field(serializer, savepoint, "testfield_l1", w_testfield_l1)
-!      CALL fs_write_field(serializer, savepoint, "testfield_l2", w_testfield_l2)
-!      CALL fs_write_field(serializer, savepoint, "testfield_l3", w_testfield_l3)
-!      CALL fs_write_field(serializer, savepoint, "testfield_l4", w_testfield_l4)
-!      CALL fs_destroy_serializer(serializer)
-!      
-!      CALL fs_create_serializer(dir, base_name, 'r', serializer)
-!      @assertTrue(fs_field_exists(serializer, "testfield_l1"))
-!      @assertTrue(fs_field_exists(serializer, "testfield_l2"))
-!      @assertTrue(fs_field_exists(serializer, "testfield_l3"))
-!      @assertTrue(fs_field_exists(serializer, "testfield_l4"))
-!      CALL fs_read_field(serializer, savepoint, "testfield_l1", r_testfield_l1)
-!      CALL fs_read_field(serializer, savepoint, "testfield_l2", r_testfield_l2)
-!      CALL fs_read_field(serializer, savepoint, "testfield_l3", r_testfield_l3)
-!      CALL fs_read_field(serializer, savepoint, "testfield_l4", r_testfield_l4)
-!      CALL fs_destroy_serializer(serializer)
-!      
-!      @assertEquivalent(w_testfield_l1, r_testfield_l1)
-!      @assertEqual(w_testfield_l2, r_testfield_l2)
-!      @assertEqual(w_testfield_l3, r_testfield_l3)
-!      @assertEqual(w_testfield_l4, r_testfield_l4)
+      CALL fs_create_serializer(dir, base_name, 'w', serializer)
+      CALL fs_write_field(serializer, savepoint, "testfield_l1", w_testfield_l1)
+      CALL fs_write_field(serializer, savepoint, "testfield_l2", w_testfield_l2)
+      CALL fs_write_field(serializer, savepoint, "testfield_l3", w_testfield_l3)
+      CALL fs_write_field(serializer, savepoint, "testfield_l4", w_testfield_l4)
+      CALL fs_destroy_serializer(serializer)
+      
+      CALL fs_create_serializer(dir, base_name, 'r', serializer)
+      @assertTrue(fs_field_exists(serializer, "testfield_l1"))
+      @assertTrue(fs_field_exists(serializer, "testfield_l2"))
+      @assertTrue(fs_field_exists(serializer, "testfield_l3"))
+      @assertTrue(fs_field_exists(serializer, "testfield_l4"))
+      CALL fs_read_field(serializer, savepoint, "testfield_l1", r_testfield_l1)
+      CALL fs_read_field(serializer, savepoint, "testfield_l2", r_testfield_l2)
+      CALL fs_read_field(serializer, savepoint, "testfield_l3", r_testfield_l3)
+      CALL fs_read_field(serializer, savepoint, "testfield_l4", r_testfield_l4)
+      CALL fs_destroy_serializer(serializer)
+      
+      @assertEquivalent(w_testfield_l1, r_testfield_l1)
+      
+      !Convert to INTEGER since pFUnit doesn't support multi-dimensional LOGICAL arrays
+      w_testfield_i2 = w_testfield_l2
+      r_testfield_i2 = r_testfield_l2
+      @assertEqual(w_testfield_i2, r_testfield_i2)
+      w_testfield_i3 = w_testfield_l3
+      r_testfield_i3 = r_testfield_l3
+      @assertEqual(w_testfield_i3, r_testfield_i3)
+      w_testfield_i4 = w_testfield_l4
+      r_testfield_i4 = r_testfield_l4
+      @assertEqual(w_testfield_i4, r_testfield_i4)
     
     END SUBROUTINE testLogicalArrays
    
@@ -127,33 +137,32 @@ CONTAINS
       CALL fs_write_field(serializer, savepoint, "testfield_i0", w_testfield_i0)
       CALL fs_write_field(serializer, savepoint, "testfield_i1", w_testfield_i1)
       CALL fs_write_field(serializer, savepoint, "testfield_l0", w_testfield_l0)
-!      CALL fs_write_field(serializer, savepoint, "testfield_l1", w_testfield_l1)
+      CALL fs_write_field(serializer, savepoint, "testfield_l1", w_testfield_l1)
       CALL fs_destroy_serializer(serializer)
       
       CALL fs_create_serializer(dir, base_name, 'r', serializer)
       
       @assertTrue(fs_field_exists(serializer, "testfield_i0"))
-      
       @assertTrue(fs_field_exists(serializer, "testfield_i1"))
       !@assertEqual(w_testfield_i1a_size, fs_get_field_size(serializer, "testfield_i1"))
       !@assertEqual(w_testfield_i1a_bounds, fs_get_field_bounds(serializer, "testfield_i1"))
       
-!      @assertTrue(fs_field_exists(serializer, "testfield_l0"))
-!      @assertTrue(fs_field_exists(serializer, "testfield_l1"))
+      @assertTrue(fs_field_exists(serializer, "testfield_l0"))
+      @assertTrue(fs_field_exists(serializer, "testfield_l1"))
       !@assertEqual(w_testfield_l1a_size, fs_get_field_size(serializer, "testfield_l1"))
       !@assertEqual(w_testfield_l1a_bounds, fs_get_field_bounds(serializer, "testfield_l1"))
       
       CALL fs_read_field(serializer, savepoint, "testfield_i0", r_testfield_i0)
       CALL fs_read_field(serializer, savepoint, "testfield_i1", r_testfield_i1)
-!      CALL fs_read_field(serializer, savepoint, "testfield_l0", r_testfield_l0)
-!      CALL fs_read_field(serializer, savepoint, "testfield_l1", r_testfield_l1)
+      CALL fs_read_field(serializer, savepoint, "testfield_l0", r_testfield_l0)
+      CALL fs_read_field(serializer, savepoint, "testfield_l1", r_testfield_l1)
       
       CALL fs_destroy_serializer(serializer)
       
       @assertEqual(w_testfield_i0, r_testfield_i0)
       @assertEqual(w_testfield_i1, r_testfield_i1)
-!      @assertEquivalent(w_testfield_l0, r_testfield_l0)
-!      @assertEquivalent(w_testfield_l1, r_testfield_l1)
+      @assertEquivalent(w_testfield_l0, r_testfield_l0)
+      @assertEquivalent(w_testfield_l1, r_testfield_l1)
     
     END SUBROUTINE testScalars
    

--- a/test/serialbox-fortran/serialbox_test.pf
+++ b/test/serialbox-fortran/serialbox_test.pf
@@ -81,7 +81,7 @@ CONTAINS
       w_testfield_l2 = RESHAPE((/ .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE. /), SHAPE(w_testfield_l2))
       w_testfield_l3 = RESHAPE((/ .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE. /), SHAPE(w_testfield_l3))
       w_testfield_l4 = RESHAPE((/ .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .TRUE. /), SHAPE(w_testfield_l4))
-!            
+            
 !      CALL fs_create_serializer(dir, base_name, 'w', serializer)
 !      CALL fs_write_field(serializer, savepoint, "testfield_l1", w_testfield_l1)
 !      CALL fs_write_field(serializer, savepoint, "testfield_l2", w_testfield_l2)
@@ -100,7 +100,7 @@ CONTAINS
 !      CALL fs_read_field(serializer, savepoint, "testfield_l4", r_testfield_l4)
 !      CALL fs_destroy_serializer(serializer)
 !      
-!      @assertEqual(w_testfield_l1, r_testfield_l1)
+!      @assertEquivalent(w_testfield_l1, r_testfield_l1)
 !      @assertEqual(w_testfield_l2, r_testfield_l2)
 !      @assertEqual(w_testfield_l3, r_testfield_l3)
 !      @assertEqual(w_testfield_l4, r_testfield_l4)
@@ -113,8 +113,8 @@ CONTAINS
       TYPE(t_serializer) :: serializer
       INTEGER :: w_testfield_i0, r_testfield_i0
       INTEGER :: w_testfield_i1(1), r_testfield_i1(1), w_testfield_i1_size(1), w_testfield_i1_bounds(2)
-      INTEGER :: w_testfield_l0, r_testfield_l0
-      INTEGER :: w_testfield_l1(1), r_testfield_l1(1), w_testfield_l1_size(1), w_testfield_l1_bounds(2)
+      LOGICAL :: w_testfield_l0, r_testfield_l0
+      LOGICAL :: w_testfield_l1(1), r_testfield_l1(1), w_testfield_l1_size(1), w_testfield_l1_bounds(2)
       
       CHARACTER(len=*), PARAMETER :: base_name = 'test_scalars'
       
@@ -127,7 +127,7 @@ CONTAINS
       CALL fs_write_field(serializer, savepoint, "testfield_i0", w_testfield_i0)
       CALL fs_write_field(serializer, savepoint, "testfield_i1", w_testfield_i1)
       CALL fs_write_field(serializer, savepoint, "testfield_l0", w_testfield_l0)
-      CALL fs_write_field(serializer, savepoint, "testfield_l1", w_testfield_l1)
+!      CALL fs_write_field(serializer, savepoint, "testfield_l1", w_testfield_l1)
       CALL fs_destroy_serializer(serializer)
       
       CALL fs_create_serializer(dir, base_name, 'r', serializer)
@@ -138,23 +138,22 @@ CONTAINS
       !@assertEqual(w_testfield_i1a_size, fs_get_field_size(serializer, "testfield_i1"))
       !@assertEqual(w_testfield_i1a_bounds, fs_get_field_bounds(serializer, "testfield_i1"))
       
-      @assertTrue(fs_field_exists(serializer, "testfield_l0"))
-      
-      @assertTrue(fs_field_exists(serializer, "testfield_l1"))
+!      @assertTrue(fs_field_exists(serializer, "testfield_l0"))
+!      @assertTrue(fs_field_exists(serializer, "testfield_l1"))
       !@assertEqual(w_testfield_l1a_size, fs_get_field_size(serializer, "testfield_l1"))
       !@assertEqual(w_testfield_l1a_bounds, fs_get_field_bounds(serializer, "testfield_l1"))
       
       CALL fs_read_field(serializer, savepoint, "testfield_i0", r_testfield_i0)
       CALL fs_read_field(serializer, savepoint, "testfield_i1", r_testfield_i1)
-      CALL fs_read_field(serializer, savepoint, "testfield_l0", r_testfield_l0)
-      CALL fs_read_field(serializer, savepoint, "testfield_l1", r_testfield_l1)
+!      CALL fs_read_field(serializer, savepoint, "testfield_l0", r_testfield_l0)
+!      CALL fs_read_field(serializer, savepoint, "testfield_l1", r_testfield_l1)
       
       CALL fs_destroy_serializer(serializer)
       
       @assertEqual(w_testfield_i0, r_testfield_i0)
       @assertEqual(w_testfield_i1, r_testfield_i1)
-      @assertEqual(w_testfield_l0, r_testfield_l0)
-      @assertEqual(w_testfield_l1, r_testfield_l1)
+!      @assertEquivalent(w_testfield_l0, r_testfield_l0)
+!      @assertEquivalent(w_testfield_l1, r_testfield_l1)
     
     END SUBROUTINE testScalars
    


### PR DESCRIPTION
Read/write routines for LOGICALs were missing in the Fortran interface. This pull request fixes this.

Since `LOGICAL` and `LOGICAL(KIND=C_BOOL)` is usually not the same in Fortran, I have added a set of routines for both types, but those for LOGICALs with default kind only delegate to the others.

I have also extended the unit tests with test cases for LOGICALs.