### PR TITLE
Rename project to serialbox2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/install" CACHE PATH "CMake install prefix")
 
-project(serialbox C CXX)
+project(serialbox2 C CXX)
 cmake_minimum_required(VERSION 3.1)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")


### PR DESCRIPTION
I'm always confused when I read `serialbox` in the project explorer.
 
Old: 
![screen shot 2017-10-27 at 10 46 55](https://user-images.githubusercontent.com/282446/32095713-580fa73e-bb04-11e7-9df6-cea29bb002b6.png)

New:
![screen shot 2017-10-27 at 10 40 47](https://user-images.githubusercontent.com/282446/32095405-5b8e8e58-bb03-11e7-8077-4813eca5c19d.png)
