### PR TITLE
Use get_filename_componet to get real path of serialbox

### DIFF
--- a/cmake/SerialboxConfig.cmake.in
+++ b/cmake/SerialboxConfig.cmake.in
@@ -98,7 +98,7 @@ set(SERIALBOX_REQUIRED_BOOST_COMPONENTS "@REQUIRED_BOOST_COMPONENTS@")
 #   Setting SERIALBOX_ROOT
 #====--------------------------------------------------------------------------------------------===
 if(NOT(DEFINED SERIALBOX_ROOT))
-  set(SERIALBOX_ROOT "${CMAKE_CURRENT_LIST_DIR}/../")
+  get_filename_component(SERIALBOX_ROOT  "${CMAKE_CURRENT_LIST_DIR}/../" REALPATH)
 endif()
 
 #===---------------------------------------------------------------------------------------------===


### PR DESCRIPTION
You get something less confusing, because it does not end with "../". Just a proposal.