### PR TITLE
Added output option to process (and rename) single file

### DIFF
--- a/src/serialbox-python/pp_ser/pp_ser.py
+++ b/src/serialbox-python/pp_ser/pp_ser.py
@@ -902,6 +902,8 @@ def parse_args():
                       default=False, action='store_true', dest='ignore_identical')
     parser.add_option('-d', '--output-dir', help='The target directory for writing pre-processed files',
                       default='', type=str, dest='output_dir')
+    parser.add_option('-o', '--output', help='Output file name to preprocess single file',
+                      default='', type=str, dest='output_file')
     parser.add_option('-v', '--verbose', help='Enable verbose execution',
                       default=False, action='store_true', dest='verbose')
     parser.add_option('-p', '--no-prefix', help='Don\'t generate preprocessing macro definition for ACC_PREFIX',
@@ -911,6 +913,8 @@ def parse_args():
     (options, args) = parser.parse_args()
     if len(args) < 1:
         parser.error('Need at least one source file to process')
+    if options.output_file and len(args) > 1:
+        parser.error('Single source file required if output file is given')
     return options, args
 
 if __name__ == "__main__":
@@ -918,6 +922,8 @@ if __name__ == "__main__":
     for infile in args:
         if options.output_dir:
             outfile = os.path.join(options.output_dir, os.path.basename(infile))
+        elif options.output_file:
+            outfile = options.output_file
         else:
             outfile = ''
 


### PR DESCRIPTION
"-o/--output" option allows to preprocess a single file and provide the output filename.