### PR TITLE
Bugfix _GLIBCXX_THROW_OR_ABORT not portable

### DIFF
--- a/src/serialbox/core/Filesystem.h
+++ b/src/serialbox/core/Filesystem.h
@@ -40,7 +40,7 @@ inline std::uintmax_t remove_all(const filesystem::path& p) {
   std::error_code ec;
   bool result = serialbox::remove_all(p, ec);
   if(ec.value())
-    _GLIBCXX_THROW_OR_ABORT(filesystem::filesystem_error("cannot remove all", p, ec));
+    throw(filesystem::filesystem_error("cannot remove all", p, ec));
   return result;
 }
 }

--- a/src/serialbox/core/Filesystem.h
+++ b/src/serialbox/core/Filesystem.h
@@ -40,7 +40,7 @@ inline std::uintmax_t remove_all(const filesystem::path& p) {
   std::error_code ec;
   bool result = serialbox::remove_all(p, ec);
   if(ec.value())
-    throw(filesystem::filesystem_error("cannot remove all", p, ec));
+    throw filesystem::filesystem_error("cannot remove all", p, ec);
   return result;
 }
 }


### PR DESCRIPTION
Bugfix: replace `_GLIBCXX_THROW_OR_ABORT` by `throw` for portability.