### PR TITLE
[compare.py] Both values NaN will no longer raise an error

### DIFF
--- a/src/serialbox-python/compare/compare.py
+++ b/src/serialbox-python/compare/compare.py
@@ -239,7 +239,7 @@ def compare_fields(serializers, field, savepoint, dim_bounds):
 
         # Check for NaN values
         num_nans += value_1_isnan + value_2_isnan
-        if value_1_isnan or value_2_isnan:
+        if value_1_isnan != value_2_isnan:
             errors += [
                 {"index": it_1.multi_index, "value_1": value_1, "value_2": value_2,
                  "error": float('nan')}]


### PR DESCRIPTION
Small change that fixes [those NaN != NaN errors](https://github.com/eth-cscs/serialbox2/issues/148).

Since everybody agreed that two NaN values shall pass as equal and I can't see a use case for the (current) opposite behavior, I haven't added a command line option as suggest by @havogt, but if you insist, I can do so.