### PR TITLE
[FTG] Reallocate

### DIFF
--- a/src/serialbox-fortran/m_ser_ftg.f90
+++ b/src/serialbox-fortran/m_ser_ftg.f90
@@ -475,8 +475,6 @@ FUNCTION ftg_match_size(fieldname, expected_rank, actual_shape)
   LOGICAL                      :: ftg_match_size
   
   expected_size = ftg_get_size(fieldname)
-  
-  WRITE(*,*) fieldname, expected_size(:expected_rank), ' : ', actual_shape
   ftg_match_size = SIZE(actual_shape) == expected_rank .AND. ALL(actual_shape == expected_size(:expected_rank))
 
 END FUNCTION ftg_match_size

--- a/src/serialbox-fortran/m_ser_ftg.f90
+++ b/src/serialbox-fortran/m_ser_ftg.f90
@@ -42,7 +42,7 @@ PUBLIC :: ignore_bullshit, ignore_bullshit_max_dim_size, ignore_bullshit_allow_n
           ftg_set_savepoint, ftg_get_savepoint, ftg_destroy_savepoint, &
           ftg_add_serializer_metainfo, ftg_get_serializer_metainfo,  ftg_add_field_metainfo, ftg_get_field_metainfo, &
           ftg_add_savepoint_metainfo, ftg_get_savepoint_metainfo, &
-          ftg_field_exists, ftg_get_bounds, ftg_register_only, ftg_write, ftg_read, &
+          ftg_field_exists, ftg_get_size, ftg_get_bounds, ftg_register_only, ftg_write, ftg_read, &
           ftg_allocate_pointer, ftg_allocate_allocatable, ftg_allocate_and_read_pointer, ftg_allocate_and_read_allocatable
 
 PRIVATE
@@ -446,6 +446,15 @@ END FUNCTION ftg_field_exists
 !=============================================================================
 !=============================================================================
 
+FUNCTION ftg_get_size(fieldname)
+
+  CHARACTER(LEN=*), INTENT(IN) :: fieldname
+  INTEGER, DIMENSION(4)        :: ftg_get_size
+
+  ftg_get_size = fs_get_size(serializer,  fieldname)
+
+END FUNCTION ftg_get_size
+
 FUNCTION ftg_get_bounds(fieldname)
 
   CHARACTER(LEN=*), INTENT(IN) :: fieldname
@@ -454,6 +463,23 @@ FUNCTION ftg_get_bounds(fieldname)
   ftg_get_bounds = fs_get_halos(serializer,  fieldname)
 
 END FUNCTION ftg_get_bounds
+
+!=============================================================================
+!=============================================================================
+
+FUNCTION ftg_match_size(fieldname, expected_rank, actual_shape)
+
+  CHARACTER(LEN=*), INTENT(IN) :: fieldname
+  INTEGER, INTENT(IN)          :: expected_rank, actual_shape(:)
+  INTEGER                      :: expected_size(4)
+  LOGICAL                      :: ftg_match_size
+  
+  expected_size = ftg_get_size(fieldname)
+  
+  WRITE(*,*) fieldname, expected_size(:expected_rank), ' : ', actual_shape
+  ftg_match_size = SIZE(actual_shape) == expected_rank .AND. ALL(actual_shape == expected_size(:expected_rank))
+
+END FUNCTION ftg_match_size
 
 !=============================================================================
 !=============================================================================
@@ -2921,6 +2947,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_logical_1d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
       CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 1, SHAPE(field))) THEN
+      NULLIFY(field)
+      CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -2933,6 +2962,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_logical_2d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
+      CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 2, SHAPE(field))) THEN
+      NULLIFY(field)
       CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -2947,6 +2979,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_logical_3d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
       CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 3, SHAPE(field))) THEN
+      NULLIFY(field)
+      CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -2959,6 +2994,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_logical_4d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
+      CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 4, SHAPE(field))) THEN
+      NULLIFY(field)
       CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -2986,6 +3024,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_bool_1d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
       CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 1, SHAPE(field))) THEN
+      NULLIFY(field)
+      CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -2998,6 +3039,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_bool_2d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
+      CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 2, SHAPE(field))) THEN
+      NULLIFY(field)
       CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3012,6 +3056,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_bool_3d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
       CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 3, SHAPE(field))) THEN
+      NULLIFY(field)
+      CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3024,6 +3071,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_bool_4d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
+      CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 4, SHAPE(field))) THEN
+      NULLIFY(field)
       CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3051,6 +3101,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_int_1d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
       CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 1, SHAPE(field))) THEN
+      NULLIFY(field)
+      CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3063,6 +3116,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_int_2d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
+      CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 2, SHAPE(field))) THEN
+      NULLIFY(field)
       CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3077,6 +3133,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_int_3d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
       CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 3, SHAPE(field))) THEN
+      NULLIFY(field)
+      CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3089,6 +3148,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_int_4d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
+      CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 4, SHAPE(field))) THEN
+      NULLIFY(field)
       CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3116,6 +3178,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_long_1d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
       CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 1, SHAPE(field))) THEN
+      NULLIFY(field)
+      CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3128,6 +3193,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_long_2d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
+      CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 2, SHAPE(field))) THEN
+      NULLIFY(field)
       CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3142,6 +3210,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_long_3d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
       CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 3, SHAPE(field))) THEN
+      NULLIFY(field)
+      CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3154,6 +3225,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_long_4d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
+      CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 4, SHAPE(field))) THEN
+      NULLIFY(field)
       CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3181,6 +3255,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_float_1d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
       CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 1, SHAPE(field))) THEN
+      NULLIFY(field)
+      CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3193,6 +3270,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_float_2d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
+      CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 2, SHAPE(field))) THEN
+      NULLIFY(field)
       CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3207,6 +3287,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_float_3d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
       CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 3, SHAPE(field))) THEN
+      NULLIFY(field)
+      CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3219,6 +3302,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_float_4d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
+      CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 4, SHAPE(field))) THEN
+      NULLIFY(field)
       CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3246,6 +3332,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_double_1d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
       CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 1, SHAPE(field))) THEN
+      NULLIFY(field)
+      CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3258,6 +3347,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_double_2d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
+      CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 2, SHAPE(field))) THEN
+      NULLIFY(field)
       CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3272,6 +3364,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_double_3d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
       CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 3, SHAPE(field))) THEN
+      NULLIFY(field)
+      CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3284,6 +3379,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_double_4d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
+      CALL ftg_allocate_pointer(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 4, SHAPE(field))) THEN
+      NULLIFY(field)
       CALL ftg_allocate_pointer(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3314,6 +3412,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_logical_1d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
       CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 1, SHAPE(field))) THEN
+      DEALLOCATE(field)
+      CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3326,6 +3427,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_logical_2d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
+      CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 2, SHAPE(field))) THEN
+      DEALLOCATE(field)
       CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3340,6 +3444,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_logical_3d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
       CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 3, SHAPE(field))) THEN
+      DEALLOCATE(field)
+      CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3352,6 +3459,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_logical_4d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
+      CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 4, SHAPE(field))) THEN
+      DEALLOCATE(field)
       CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3379,6 +3489,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_bool_1d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
       CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 1, SHAPE(field))) THEN
+      DEALLOCATE(field)
+      CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3391,6 +3504,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_bool_2d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
+      CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 2, SHAPE(field))) THEN
+      DEALLOCATE(field)
       CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3405,6 +3521,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_bool_3d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
       CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 3, SHAPE(field))) THEN
+      DEALLOCATE(field)
+      CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3417,6 +3536,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_bool_4d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
+      CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 4, SHAPE(field))) THEN
+      DEALLOCATE(field)
       CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3444,6 +3566,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_int_1d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
       CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 1, SHAPE(field))) THEN
+      DEALLOCATE(field)
+      CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3456,6 +3581,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_int_2d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
+      CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 2, SHAPE(field))) THEN
+      DEALLOCATE(field)
       CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3470,6 +3598,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_int_3d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
       CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 3, SHAPE(field))) THEN
+      DEALLOCATE(field)
+      CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3482,6 +3613,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_int_4d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
+      CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 4, SHAPE(field))) THEN
+      DEALLOCATE(field)
       CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3509,6 +3643,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_long_1d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
       CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 1, SHAPE(field))) THEN
+      DEALLOCATE(field)
+      CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3521,6 +3658,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_long_2d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
+      CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 2, SHAPE(field))) THEN
+      DEALLOCATE(field)
       CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3535,6 +3675,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_long_3d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
       CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 3, SHAPE(field))) THEN
+      DEALLOCATE(field)
+      CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3547,6 +3690,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_long_4d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
+      CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 4, SHAPE(field))) THEN
+      DEALLOCATE(field)
       CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3574,6 +3720,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_float_1d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
       CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 1, SHAPE(field))) THEN
+      DEALLOCATE(field)
+      CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3586,6 +3735,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_float_2d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
+      CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 2, SHAPE(field))) THEN
+      DEALLOCATE(field)
       CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3600,6 +3752,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_float_3d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
       CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 3, SHAPE(field))) THEN
+      DEALLOCATE(field)
+      CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3612,6 +3767,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_float_4d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
+      CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 4, SHAPE(field))) THEN
+      DEALLOCATE(field)
       CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3639,6 +3797,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_double_1d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
       CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 1, SHAPE(field))) THEN
+      DEALLOCATE(field)
+      CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3651,6 +3812,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_double_2d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
+      CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 2, SHAPE(field))) THEN
+      DEALLOCATE(field)
       CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
@@ -3665,6 +3829,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_double_3d(fieldname, field)
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
       CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 3, SHAPE(field))) THEN
+      DEALLOCATE(field)
+      CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)
   END IF
@@ -3677,6 +3844,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_double_4d(fieldname, field)
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
+      CALL ftg_allocate_allocatable(fieldname, field)
+    ELSE IF (.NOT. ftg_match_size(fieldname, 4, SHAPE(field))) THEN
+      DEALLOCATE(field)
       CALL ftg_allocate_allocatable(fieldname, field)
     END IF
     CALL ftg_read(fieldname, field)

--- a/src/serialbox-fortran/m_ser_ftg.f90
+++ b/src/serialbox-fortran/m_ser_ftg.f90
@@ -1686,7 +1686,7 @@ END SUBROUTINE ftg_write_double_4d
 !=============================================================================
 
 SUBROUTINE ftg_read_logical_0d(fieldname, field)
-  CHARACTER(LEN=*)             :: fieldname
+  CHARACTER(LEN=*), INTENT(IN) :: fieldname
   LOGICAL, INTENT(OUT), TARGET :: field
   LOGICAL                      :: registered_only
 
@@ -1699,7 +1699,7 @@ SUBROUTINE ftg_read_logical_0d(fieldname, field)
 END SUBROUTINE ftg_read_logical_0d
 
 SUBROUTINE ftg_read_logical_1d(fieldname, field)
-  CHARACTER(LEN=*)             :: fieldname
+  CHARACTER(LEN=*), INTENT(IN) :: fieldname
   LOGICAL, INTENT(OUT), TARGET :: field(:)
   LOGICAL                      :: registered_only
 
@@ -1712,7 +1712,7 @@ SUBROUTINE ftg_read_logical_1d(fieldname, field)
 END SUBROUTINE ftg_read_logical_1d
 
 SUBROUTINE ftg_read_logical_2d(fieldname, field)
-  CHARACTER(LEN=*)             :: fieldname
+  CHARACTER(LEN=*), INTENT(IN) :: fieldname
   LOGICAL, INTENT(OUT), TARGET :: field(:,:)
   LOGICAL                      :: registered_only
 
@@ -1725,7 +1725,7 @@ SUBROUTINE ftg_read_logical_2d(fieldname, field)
 END SUBROUTINE ftg_read_logical_2d
 
 SUBROUTINE ftg_read_logical_3d(fieldname, field)
-  CHARACTER(LEN=*)             :: fieldname
+  CHARACTER(LEN=*), INTENT(IN) :: fieldname
   LOGICAL, INTENT(OUT), TARGET :: field(:,:,:)
   LOGICAL                      :: registered_only
 
@@ -1738,7 +1738,7 @@ SUBROUTINE ftg_read_logical_3d(fieldname, field)
 END SUBROUTINE ftg_read_logical_3d
 
 SUBROUTINE ftg_read_logical_4d(fieldname, field)
-  CHARACTER(LEN=*)             :: fieldname
+  CHARACTER(LEN=*), INTENT(IN) :: fieldname
   LOGICAL, INTENT(OUT), TARGET :: field(:,:,:,:)
   LOGICAL                      :: registered_only
 
@@ -1751,7 +1751,7 @@ SUBROUTINE ftg_read_logical_4d(fieldname, field)
 END SUBROUTINE ftg_read_logical_4d
 
 SUBROUTINE ftg_read_bool_0d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)              :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), TARGET :: field
   LOGICAL                                   :: registered_only
 
@@ -1764,7 +1764,7 @@ SUBROUTINE ftg_read_bool_0d(fieldname, field)
 END SUBROUTINE ftg_read_bool_0d
 
 SUBROUTINE ftg_read_bool_1d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)              :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), TARGET :: field(:)
   LOGICAL                                   :: registered_only
 
@@ -1777,7 +1777,7 @@ SUBROUTINE ftg_read_bool_1d(fieldname, field)
 END SUBROUTINE ftg_read_bool_1d
 
 SUBROUTINE ftg_read_bool_2d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)              :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), TARGET :: field(:,:)
   LOGICAL                                   :: registered_only
 
@@ -1790,7 +1790,7 @@ SUBROUTINE ftg_read_bool_2d(fieldname, field)
 END SUBROUTINE ftg_read_bool_2d
 
 SUBROUTINE ftg_read_bool_3d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)              :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), TARGET :: field(:,:,:)
   LOGICAL                                   :: registered_only
 
@@ -1803,7 +1803,7 @@ SUBROUTINE ftg_read_bool_3d(fieldname, field)
 END SUBROUTINE ftg_read_bool_3d
 
 SUBROUTINE ftg_read_bool_4d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)              :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), TARGET :: field(:,:,:,:)
   LOGICAL                                   :: registered_only
 
@@ -1816,7 +1816,7 @@ SUBROUTINE ftg_read_bool_4d(fieldname, field)
 END SUBROUTINE ftg_read_bool_4d
 
 SUBROUTINE ftg_read_int_0d(fieldname, field)
-  CHARACTER(LEN=*)             :: fieldname
+  CHARACTER(LEN=*), INTENT(IN) :: fieldname
   INTEGER, INTENT(OUT), TARGET :: field
   LOGICAL                      :: registered_only
 
@@ -1829,7 +1829,7 @@ SUBROUTINE ftg_read_int_0d(fieldname, field)
 END SUBROUTINE ftg_read_int_0d
 
 SUBROUTINE ftg_read_int_1d(fieldname, field)
-  CHARACTER(LEN=*)             :: fieldname
+  CHARACTER(LEN=*), INTENT(IN) :: fieldname
   INTEGER, INTENT(OUT), TARGET :: field(:)
   LOGICAL                      :: registered_only
 
@@ -1842,7 +1842,7 @@ SUBROUTINE ftg_read_int_1d(fieldname, field)
 END SUBROUTINE ftg_read_int_1d
 
 SUBROUTINE ftg_read_int_2d(fieldname, field)
-  CHARACTER(LEN=*)             :: fieldname
+  CHARACTER(LEN=*), INTENT(IN) :: fieldname
   INTEGER, INTENT(OUT), TARGET :: field(:,:)
   LOGICAL                      :: registered_only
 
@@ -1855,7 +1855,7 @@ SUBROUTINE ftg_read_int_2d(fieldname, field)
 END SUBROUTINE ftg_read_int_2d
 
 SUBROUTINE ftg_read_int_3d(fieldname, field)
-  CHARACTER(LEN=*)             :: fieldname
+  CHARACTER(LEN=*), INTENT(IN) :: fieldname
   INTEGER, INTENT(OUT), TARGET :: field(:,:,:)
   LOGICAL                      :: registered_only
 
@@ -1868,7 +1868,7 @@ SUBROUTINE ftg_read_int_3d(fieldname, field)
 END SUBROUTINE ftg_read_int_3d
 
 SUBROUTINE ftg_read_int_4d(fieldname, field)
-  CHARACTER(LEN=*)             :: fieldname
+  CHARACTER(LEN=*), INTENT(IN) :: fieldname
   INTEGER, INTENT(OUT), TARGET :: field(:,:,:,:)
   LOGICAL                      :: registered_only
 
@@ -1881,7 +1881,7 @@ SUBROUTINE ftg_read_int_4d(fieldname, field)
 END SUBROUTINE ftg_read_int_4d
 
 SUBROUTINE ftg_read_long_0d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)              :: fieldname
   INTEGER(KIND=C_LONG), INTENT(OUT), TARGET :: field
   LOGICAL                                   :: registered_only
 
@@ -1894,7 +1894,7 @@ SUBROUTINE ftg_read_long_0d(fieldname, field)
 END SUBROUTINE ftg_read_long_0d
 
 SUBROUTINE ftg_read_long_1d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)              :: fieldname
   INTEGER(KIND=C_LONG), INTENT(OUT), TARGET :: field(:)
   LOGICAL                                   :: registered_only
 
@@ -1907,7 +1907,7 @@ SUBROUTINE ftg_read_long_1d(fieldname, field)
 END SUBROUTINE ftg_read_long_1d
 
 SUBROUTINE ftg_read_long_2d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)              :: fieldname
   INTEGER(KIND=C_LONG), INTENT(OUT), TARGET :: field(:,:)
   LOGICAL                                   :: registered_only
 
@@ -1920,7 +1920,7 @@ SUBROUTINE ftg_read_long_2d(fieldname, field)
 END SUBROUTINE ftg_read_long_2d
 
 SUBROUTINE ftg_read_long_3d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)              :: fieldname
   INTEGER(KIND=C_LONG), INTENT(OUT), TARGET :: field(:,:,:)
   LOGICAL                                   :: registered_only
 
@@ -1933,7 +1933,7 @@ SUBROUTINE ftg_read_long_3d(fieldname, field)
 END SUBROUTINE ftg_read_long_3d
 
 SUBROUTINE ftg_read_long_4d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)              :: fieldname
   INTEGER(KIND=C_LONG), INTENT(OUT), TARGET :: field(:,:,:,:)
   LOGICAL                                   :: registered_only
 
@@ -1946,7 +1946,7 @@ SUBROUTINE ftg_read_long_4d(fieldname, field)
 END SUBROUTINE ftg_read_long_4d
 
 SUBROUTINE ftg_read_float_0d(fieldname, field)
-  CHARACTER(LEN=*)                        :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)            :: fieldname
   REAL(KIND=C_FLOAT), INTENT(OUT), TARGET :: field
   LOGICAL                                 :: registered_only
 
@@ -1959,7 +1959,7 @@ SUBROUTINE ftg_read_float_0d(fieldname, field)
 END SUBROUTINE ftg_read_float_0d
 
 SUBROUTINE ftg_read_float_1d(fieldname, field)
-  CHARACTER(LEN=*)                        :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)            :: fieldname
   REAL(KIND=C_FLOAT), INTENT(OUT), TARGET :: field(:)
   LOGICAL                                 :: registered_only
 
@@ -1972,7 +1972,7 @@ SUBROUTINE ftg_read_float_1d(fieldname, field)
 END SUBROUTINE ftg_read_float_1d
 
 SUBROUTINE ftg_read_float_2d(fieldname, field)
-  CHARACTER(LEN=*)                        :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)            :: fieldname
   REAL(KIND=C_FLOAT), INTENT(OUT), TARGET :: field(:,:)
   LOGICAL                                 :: registered_only
 
@@ -1985,7 +1985,7 @@ SUBROUTINE ftg_read_float_2d(fieldname, field)
 END SUBROUTINE ftg_read_float_2d
 
 SUBROUTINE ftg_read_float_3d(fieldname, field)
-  CHARACTER(LEN=*)                        :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)            :: fieldname
   REAL(KIND=C_FLOAT), INTENT(OUT), TARGET :: field(:,:,:)
   LOGICAL                                 :: registered_only
 
@@ -1998,7 +1998,7 @@ SUBROUTINE ftg_read_float_3d(fieldname, field)
 END SUBROUTINE ftg_read_float_3d
 
 SUBROUTINE ftg_read_float_4d(fieldname, field)
-  CHARACTER(LEN=*)                        :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)            :: fieldname
   REAL(KIND=C_FLOAT), INTENT(OUT), TARGET :: field(:,:,:,:)
   LOGICAL                                 :: registered_only
 
@@ -2011,7 +2011,7 @@ SUBROUTINE ftg_read_float_4d(fieldname, field)
 END SUBROUTINE ftg_read_float_4d
 
 SUBROUTINE ftg_read_double_0d(fieldname, field)
-  CHARACTER(LEN=*)                         :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)             :: fieldname
   REAL(KIND=C_DOUBLE), INTENT(OUT), TARGET :: field
   LOGICAL                                  :: registered_only
 
@@ -2024,7 +2024,7 @@ SUBROUTINE ftg_read_double_0d(fieldname, field)
 END SUBROUTINE ftg_read_double_0d
 
 SUBROUTINE ftg_read_double_1d(fieldname, field)
-  CHARACTER(LEN=*)                         :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)             :: fieldname
   REAL(KIND=C_DOUBLE), INTENT(OUT), TARGET :: field(:)
   LOGICAL                                  :: registered_only
 
@@ -2037,7 +2037,7 @@ SUBROUTINE ftg_read_double_1d(fieldname, field)
 END SUBROUTINE ftg_read_double_1d
 
 SUBROUTINE ftg_read_double_2d(fieldname, field)
-  CHARACTER(LEN=*)                         :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)             :: fieldname
   REAL(KIND=C_DOUBLE), INTENT(OUT), TARGET :: field(:,:)
   LOGICAL                                  :: registered_only
 
@@ -2050,7 +2050,7 @@ SUBROUTINE ftg_read_double_2d(fieldname, field)
 END SUBROUTINE ftg_read_double_2d
 
 SUBROUTINE ftg_read_double_3d(fieldname, field)
-  CHARACTER(LEN=*)                         :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)             :: fieldname
   REAL(KIND=C_DOUBLE), INTENT(OUT), TARGET :: field(:,:,:)
   LOGICAL                                  :: registered_only
 
@@ -2063,7 +2063,7 @@ SUBROUTINE ftg_read_double_3d(fieldname, field)
 END SUBROUTINE ftg_read_double_3d
 
 SUBROUTINE ftg_read_double_4d(fieldname, field)
-  CHARACTER(LEN=*)                         :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)             :: fieldname
   REAL(KIND=C_DOUBLE), INTENT(OUT), TARGET :: field(:,:,:,:)
   LOGICAL                                  :: registered_only
 
@@ -2079,7 +2079,7 @@ END SUBROUTINE ftg_read_double_4d
 !=============================================================================
 
 SUBROUTINE ftg_allocate_pointer_logical_0d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)  :: fieldname
   LOGICAL, INTENT(OUT), POINTER :: field
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2094,7 +2094,7 @@ SUBROUTINE ftg_allocate_pointer_logical_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_logical_0d
 
 SUBROUTINE ftg_allocate_pointer_logical_1d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)  :: fieldname
   LOGICAL, INTENT(OUT), POINTER :: field(:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2109,7 +2109,7 @@ SUBROUTINE ftg_allocate_pointer_logical_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_logical_1d
 
 SUBROUTINE ftg_allocate_pointer_logical_2d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)  :: fieldname
   LOGICAL, INTENT(OUT), POINTER :: field(:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2124,7 +2124,7 @@ SUBROUTINE ftg_allocate_pointer_logical_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_logical_2d
 
 SUBROUTINE ftg_allocate_pointer_logical_3d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)  :: fieldname
   LOGICAL, INTENT(OUT), POINTER :: field(:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2139,7 +2139,7 @@ SUBROUTINE ftg_allocate_pointer_logical_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_logical_3d
 
 SUBROUTINE ftg_allocate_pointer_logical_4d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)  :: fieldname
   LOGICAL, INTENT(OUT), POINTER :: field(:,:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2154,7 +2154,7 @@ SUBROUTINE ftg_allocate_pointer_logical_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_logical_4d
 
 SUBROUTINE ftg_allocate_pointer_bool_0d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)               :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), POINTER :: field
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2169,7 +2169,7 @@ SUBROUTINE ftg_allocate_pointer_bool_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_bool_0d
 
 SUBROUTINE ftg_allocate_pointer_bool_1d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)               :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), POINTER :: field(:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2184,7 +2184,7 @@ SUBROUTINE ftg_allocate_pointer_bool_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_bool_1d
 
 SUBROUTINE ftg_allocate_pointer_bool_2d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)               :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), POINTER :: field(:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2199,7 +2199,7 @@ SUBROUTINE ftg_allocate_pointer_bool_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_bool_2d
 
 SUBROUTINE ftg_allocate_pointer_bool_3d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)               :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), POINTER :: field(:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2214,7 +2214,7 @@ SUBROUTINE ftg_allocate_pointer_bool_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_bool_3d
 
 SUBROUTINE ftg_allocate_pointer_bool_4d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)               :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), POINTER :: field(:,:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2229,7 +2229,7 @@ SUBROUTINE ftg_allocate_pointer_bool_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_bool_4d
 
 SUBROUTINE ftg_allocate_pointer_int_0d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)  :: fieldname
   INTEGER, INTENT(OUT), POINTER :: field
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2244,7 +2244,7 @@ SUBROUTINE ftg_allocate_pointer_int_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_int_0d
 
 SUBROUTINE ftg_allocate_pointer_int_1d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)  :: fieldname
   INTEGER, INTENT(OUT), POINTER :: field(:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2259,7 +2259,7 @@ SUBROUTINE ftg_allocate_pointer_int_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_int_1d
 
 SUBROUTINE ftg_allocate_pointer_int_2d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)  :: fieldname
   INTEGER, INTENT(OUT), POINTER :: field(:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2274,7 +2274,7 @@ SUBROUTINE ftg_allocate_pointer_int_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_int_2d
 
 SUBROUTINE ftg_allocate_pointer_int_3d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)  :: fieldname
   INTEGER, INTENT(OUT), POINTER :: field(:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2289,7 +2289,7 @@ SUBROUTINE ftg_allocate_pointer_int_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_int_3d
 
 SUBROUTINE ftg_allocate_pointer_int_4d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)  :: fieldname
   INTEGER, INTENT(OUT), POINTER :: field(:,:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2304,7 +2304,7 @@ SUBROUTINE ftg_allocate_pointer_int_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_int_4d
 
 SUBROUTINE ftg_allocate_pointer_long_0d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)               :: fieldname
   INTEGER(KIND=C_LONG), INTENT(OUT), POINTER :: field
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2319,7 +2319,7 @@ SUBROUTINE ftg_allocate_pointer_long_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_long_0d
 
 SUBROUTINE ftg_allocate_pointer_long_1d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)               :: fieldname
   INTEGER(KIND=C_LONG), INTENT(OUT), POINTER :: field(:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2334,7 +2334,7 @@ SUBROUTINE ftg_allocate_pointer_long_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_long_1d
 
 SUBROUTINE ftg_allocate_pointer_long_2d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)               :: fieldname
   INTEGER(KIND=C_LONG), INTENT(OUT), POINTER :: field(:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2349,7 +2349,7 @@ SUBROUTINE ftg_allocate_pointer_long_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_long_2d
 
 SUBROUTINE ftg_allocate_pointer_long_3d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)               :: fieldname
   INTEGER(KIND=C_LONG), INTENT(OUT), POINTER :: field(:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2364,7 +2364,7 @@ SUBROUTINE ftg_allocate_pointer_long_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_long_3d
 
 SUBROUTINE ftg_allocate_pointer_long_4d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)               :: fieldname
   INTEGER(KIND=C_LONG), INTENT(OUT), POINTER :: field(:,:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2379,7 +2379,7 @@ SUBROUTINE ftg_allocate_pointer_long_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_long_4d
 
 SUBROUTINE ftg_allocate_pointer_float_0d(fieldname, field)
-  CHARACTER(LEN=*)                         :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)             :: fieldname
   REAL(KIND=C_FLOAT), INTENT(OUT), POINTER :: field
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2394,7 +2394,7 @@ SUBROUTINE ftg_allocate_pointer_float_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_float_0d
 
 SUBROUTINE ftg_allocate_pointer_float_1d(fieldname, field)
-  CHARACTER(LEN=*)                         :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)             :: fieldname
   REAL(KIND=C_FLOAT), INTENT(OUT), POINTER :: field(:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2409,7 +2409,7 @@ SUBROUTINE ftg_allocate_pointer_float_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_float_1d
 
 SUBROUTINE ftg_allocate_pointer_float_2d(fieldname, field)
-  CHARACTER(LEN=*)                         :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)             :: fieldname
   REAL(KIND=C_FLOAT), INTENT(OUT), POINTER :: field(:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2424,7 +2424,7 @@ SUBROUTINE ftg_allocate_pointer_float_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_float_2d
 
 SUBROUTINE ftg_allocate_pointer_float_3d(fieldname, field)
-  CHARACTER(LEN=*)                         :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)             :: fieldname
   REAL(KIND=C_FLOAT), INTENT(OUT), POINTER :: field(:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2439,7 +2439,7 @@ SUBROUTINE ftg_allocate_pointer_float_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_float_3d
 
 SUBROUTINE ftg_allocate_pointer_float_4d(fieldname, field)
-  CHARACTER(LEN=*)                         :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)             :: fieldname
   REAL(KIND=C_FLOAT), INTENT(OUT), POINTER :: field(:,:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2454,7 +2454,7 @@ SUBROUTINE ftg_allocate_pointer_float_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_float_4d
 
 SUBROUTINE ftg_allocate_pointer_double_0d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)              :: fieldname
   REAL(KIND=C_DOUBLE), INTENT(OUT), POINTER :: field
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2469,7 +2469,7 @@ SUBROUTINE ftg_allocate_pointer_double_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_double_0d
 
 SUBROUTINE ftg_allocate_pointer_double_1d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)              :: fieldname
   REAL(KIND=C_DOUBLE), INTENT(OUT), POINTER :: field(:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2484,7 +2484,7 @@ SUBROUTINE ftg_allocate_pointer_double_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_double_1d
 
 SUBROUTINE ftg_allocate_pointer_double_2d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)              :: fieldname
   REAL(KIND=C_DOUBLE), INTENT(OUT), POINTER :: field(:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2499,7 +2499,7 @@ SUBROUTINE ftg_allocate_pointer_double_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_double_2d
 
 SUBROUTINE ftg_allocate_pointer_double_3d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)              :: fieldname
   REAL(KIND=C_DOUBLE), INTENT(OUT), POINTER :: field(:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2514,7 +2514,7 @@ SUBROUTINE ftg_allocate_pointer_double_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_pointer_double_3d
 
 SUBROUTINE ftg_allocate_pointer_double_4d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)              :: fieldname
   REAL(KIND=C_DOUBLE), INTENT(OUT), POINTER :: field(:,:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2532,7 +2532,7 @@ END SUBROUTINE ftg_allocate_pointer_double_4d
 !=============================================================================
 
 SUBROUTINE ftg_allocate_allocatable_logical_0d(fieldname, field)
-  CHARACTER(LEN=*)                  :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)      :: fieldname
   LOGICAL, INTENT(OUT), ALLOCATABLE :: field
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2545,7 +2545,7 @@ SUBROUTINE ftg_allocate_allocatable_logical_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_logical_0d
 
 SUBROUTINE ftg_allocate_allocatable_logical_1d(fieldname, field)
-  CHARACTER(LEN=*)                  :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)      :: fieldname
   LOGICAL, INTENT(OUT), ALLOCATABLE :: field(:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2558,7 +2558,7 @@ SUBROUTINE ftg_allocate_allocatable_logical_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_logical_1d
 
 SUBROUTINE ftg_allocate_allocatable_logical_2d(fieldname, field)
-  CHARACTER(LEN=*)                  :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)      :: fieldname
   LOGICAL, INTENT(OUT), ALLOCATABLE :: field(:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2571,7 +2571,7 @@ SUBROUTINE ftg_allocate_allocatable_logical_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_logical_2d
 
 SUBROUTINE ftg_allocate_allocatable_logical_3d(fieldname, field)
-  CHARACTER(LEN=*)                  :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)      :: fieldname
   LOGICAL, INTENT(OUT), ALLOCATABLE :: field(:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2584,7 +2584,7 @@ SUBROUTINE ftg_allocate_allocatable_logical_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_logical_3d
 
 SUBROUTINE ftg_allocate_allocatable_logical_4d(fieldname, field)
-  CHARACTER(LEN=*)                  :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)      :: fieldname
   LOGICAL, INTENT(OUT), ALLOCATABLE :: field(:,:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2597,7 +2597,7 @@ SUBROUTINE ftg_allocate_allocatable_logical_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_logical_4d
 
 SUBROUTINE ftg_allocate_allocatable_bool_0d(fieldname, field)
-  CHARACTER(LEN=*)                               :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                   :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), ALLOCATABLE :: field
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2610,7 +2610,7 @@ SUBROUTINE ftg_allocate_allocatable_bool_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_bool_0d
 
 SUBROUTINE ftg_allocate_allocatable_bool_1d(fieldname, field)
-  CHARACTER(LEN=*)                               :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                   :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), ALLOCATABLE :: field(:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2623,7 +2623,7 @@ SUBROUTINE ftg_allocate_allocatable_bool_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_bool_1d
 
 SUBROUTINE ftg_allocate_allocatable_bool_2d(fieldname, field)
-  CHARACTER(LEN=*)                               :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                   :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), ALLOCATABLE :: field(:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2636,7 +2636,7 @@ SUBROUTINE ftg_allocate_allocatable_bool_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_bool_2d
 
 SUBROUTINE ftg_allocate_allocatable_bool_3d(fieldname, field)
-  CHARACTER(LEN=*)                               :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                   :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), ALLOCATABLE :: field(:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2649,7 +2649,7 @@ SUBROUTINE ftg_allocate_allocatable_bool_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_bool_3d
 
 SUBROUTINE ftg_allocate_allocatable_bool_4d(fieldname, field)
-  CHARACTER(LEN=*)                               :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                   :: fieldname
   LOGICAL(KIND=C_BOOL), INTENT(OUT), ALLOCATABLE :: field(:,:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2662,7 +2662,7 @@ SUBROUTINE ftg_allocate_allocatable_bool_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_bool_4d
 
 SUBROUTINE ftg_allocate_allocatable_int_0d(fieldname, field)
-  CHARACTER(LEN=*)                  :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)      :: fieldname
   INTEGER, INTENT(OUT), ALLOCATABLE :: field
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2675,7 +2675,7 @@ SUBROUTINE ftg_allocate_allocatable_int_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_int_0d
 
 SUBROUTINE ftg_allocate_allocatable_int_1d(fieldname, field)
-  CHARACTER(LEN=*)                  :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)      :: fieldname
   INTEGER, INTENT(OUT), ALLOCATABLE :: field(:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2688,7 +2688,7 @@ SUBROUTINE ftg_allocate_allocatable_int_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_int_1d
 
 SUBROUTINE ftg_allocate_allocatable_int_2d(fieldname, field)
-  CHARACTER(LEN=*)                  :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)      :: fieldname
   INTEGER, INTENT(OUT), ALLOCATABLE :: field(:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2701,7 +2701,7 @@ SUBROUTINE ftg_allocate_allocatable_int_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_int_2d
 
 SUBROUTINE ftg_allocate_allocatable_int_3d(fieldname, field)
-  CHARACTER(LEN=*)                  :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)      :: fieldname
   INTEGER, INTENT(OUT), ALLOCATABLE :: field(:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2714,7 +2714,7 @@ SUBROUTINE ftg_allocate_allocatable_int_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_int_3d
 
 SUBROUTINE ftg_allocate_allocatable_int_4d(fieldname, field)
-  CHARACTER(LEN=*)                  :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)      :: fieldname
   INTEGER, INTENT(OUT), ALLOCATABLE :: field(:,:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2727,7 +2727,7 @@ SUBROUTINE ftg_allocate_allocatable_int_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_int_4d
 
 SUBROUTINE ftg_allocate_allocatable_long_0d(fieldname, field)
-  CHARACTER(LEN=*)                               :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                   :: fieldname
   INTEGER(KIND=C_LONG), INTENT(OUT), ALLOCATABLE :: field
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2740,7 +2740,7 @@ SUBROUTINE ftg_allocate_allocatable_long_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_long_0d
 
 SUBROUTINE ftg_allocate_allocatable_long_1d(fieldname, field)
-  CHARACTER(LEN=*)                               :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                   :: fieldname
   INTEGER(KIND=C_LONG), INTENT(OUT), ALLOCATABLE :: field(:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2753,7 +2753,7 @@ SUBROUTINE ftg_allocate_allocatable_long_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_long_1d
 
 SUBROUTINE ftg_allocate_allocatable_long_2d(fieldname, field)
-  CHARACTER(LEN=*)                               :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                   :: fieldname
   INTEGER(KIND=C_LONG), INTENT(OUT), ALLOCATABLE :: field(:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2766,7 +2766,7 @@ SUBROUTINE ftg_allocate_allocatable_long_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_long_2d
 
 SUBROUTINE ftg_allocate_allocatable_long_3d(fieldname, field)
-  CHARACTER(LEN=*)                               :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                   :: fieldname
   INTEGER(KIND=C_LONG), INTENT(OUT), ALLOCATABLE :: field(:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2779,7 +2779,7 @@ SUBROUTINE ftg_allocate_allocatable_long_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_long_3d
 
 SUBROUTINE ftg_allocate_allocatable_long_4d(fieldname, field)
-  CHARACTER(LEN=*)                               :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                   :: fieldname
   INTEGER(KIND=C_LONG), INTENT(OUT), ALLOCATABLE :: field(:,:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2792,7 +2792,7 @@ SUBROUTINE ftg_allocate_allocatable_long_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_long_4d
 
 SUBROUTINE ftg_allocate_allocatable_float_0d(fieldname, field)
-  CHARACTER(LEN=*)                             :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                 :: fieldname
   REAL(KIND=C_FLOAT), INTENT(OUT), ALLOCATABLE :: field
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2805,7 +2805,7 @@ SUBROUTINE ftg_allocate_allocatable_float_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_float_0d
 
 SUBROUTINE ftg_allocate_allocatable_float_1d(fieldname, field)
-  CHARACTER(LEN=*)                             :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                 :: fieldname
   REAL(KIND=C_FLOAT), INTENT(OUT), ALLOCATABLE :: field(:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2818,7 +2818,7 @@ SUBROUTINE ftg_allocate_allocatable_float_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_float_1d
 
 SUBROUTINE ftg_allocate_allocatable_float_2d(fieldname, field)
-  CHARACTER(LEN=*)                             :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                 :: fieldname
   REAL(KIND=C_FLOAT), INTENT(OUT), ALLOCATABLE :: field(:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2831,7 +2831,7 @@ SUBROUTINE ftg_allocate_allocatable_float_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_float_2d
 
 SUBROUTINE ftg_allocate_allocatable_float_3d(fieldname, field)
-  CHARACTER(LEN=*)                             :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                 :: fieldname
   REAL(KIND=C_FLOAT), INTENT(OUT), ALLOCATABLE :: field(:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2844,7 +2844,7 @@ SUBROUTINE ftg_allocate_allocatable_float_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_float_3d
 
 SUBROUTINE ftg_allocate_allocatable_float_4d(fieldname, field)
-  CHARACTER(LEN=*)                             :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                 :: fieldname
   REAL(KIND=C_FLOAT), INTENT(OUT), ALLOCATABLE :: field(:,:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2857,7 +2857,7 @@ SUBROUTINE ftg_allocate_allocatable_float_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_float_4d
 
 SUBROUTINE ftg_allocate_allocatable_double_0d(fieldname, field)
-  CHARACTER(LEN=*)                              :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                  :: fieldname
   REAL(KIND=C_DOUBLE), INTENT(OUT), ALLOCATABLE :: field
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2870,7 +2870,7 @@ SUBROUTINE ftg_allocate_allocatable_double_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_double_0d
 
 SUBROUTINE ftg_allocate_allocatable_double_1d(fieldname, field)
-  CHARACTER(LEN=*)                              :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                  :: fieldname
   REAL(KIND=C_DOUBLE), INTENT(OUT), ALLOCATABLE :: field(:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2883,7 +2883,7 @@ SUBROUTINE ftg_allocate_allocatable_double_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_double_1d
 
 SUBROUTINE ftg_allocate_allocatable_double_2d(fieldname, field)
-  CHARACTER(LEN=*)                              :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                  :: fieldname
   REAL(KIND=C_DOUBLE), INTENT(OUT), ALLOCATABLE :: field(:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2896,7 +2896,7 @@ SUBROUTINE ftg_allocate_allocatable_double_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_double_2d
 
 SUBROUTINE ftg_allocate_allocatable_double_3d(fieldname, field)
-  CHARACTER(LEN=*)                              :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                  :: fieldname
   REAL(KIND=C_DOUBLE), INTENT(OUT), ALLOCATABLE :: field(:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2909,7 +2909,7 @@ SUBROUTINE ftg_allocate_allocatable_double_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_allocatable_double_3d
 
 SUBROUTINE ftg_allocate_allocatable_double_4d(fieldname, field)
-  CHARACTER(LEN=*)                              :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)                  :: fieldname
   REAL(KIND=C_DOUBLE), INTENT(OUT), ALLOCATABLE :: field(:,:,:,:)
 
   INTEGER, DIMENSION(8) :: bounds
@@ -2925,9 +2925,9 @@ END SUBROUTINE ftg_allocate_allocatable_double_4d
 !=============================================================================
 
 SUBROUTINE ftg_allocate_and_read_pointer_logical_0d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
-  LOGICAL, INTENT(OUT), POINTER :: field
-  LOGICAL                       :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)    :: fieldname
+  LOGICAL, INTENT(INOUT), POINTER :: field
+  LOGICAL                         :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -2938,9 +2938,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_logical_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_logical_0d
 
 SUBROUTINE ftg_allocate_and_read_pointer_logical_1d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
-  LOGICAL, INTENT(OUT), POINTER :: field(:)
-  LOGICAL                       :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)    :: fieldname
+  LOGICAL, INTENT(INOUT), POINTER :: field(:)
+  LOGICAL                         :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -2954,9 +2954,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_logical_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_logical_1d
 
 SUBROUTINE ftg_allocate_and_read_pointer_logical_2d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
-  LOGICAL, INTENT(OUT), POINTER :: field(:,:)
-  LOGICAL                       :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)    :: fieldname
+  LOGICAL, INTENT(INOUT), POINTER :: field(:,:)
+  LOGICAL                         :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -2970,9 +2970,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_logical_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_logical_2d
 
 SUBROUTINE ftg_allocate_and_read_pointer_logical_3d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
-  LOGICAL, INTENT(OUT), POINTER :: field(:,:,:)
-  LOGICAL                       :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)    :: fieldname
+  LOGICAL, INTENT(INOUT), POINTER :: field(:,:,:)
+  LOGICAL                         :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -2986,9 +2986,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_logical_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_logical_3d
 
 SUBROUTINE ftg_allocate_and_read_pointer_logical_4d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
-  LOGICAL, INTENT(OUT), POINTER :: field(:,:,:,:)
-  LOGICAL                       :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)    :: fieldname
+  LOGICAL, INTENT(INOUT), POINTER :: field(:,:,:,:)
+  LOGICAL                         :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3002,9 +3002,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_logical_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_logical_4d
 
 SUBROUTINE ftg_allocate_and_read_pointer_bool_0d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
-  LOGICAL(KIND=C_BOOL), INTENT(OUT), POINTER :: field
-  LOGICAL                                    :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                 :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(INOUT), POINTER :: field
+  LOGICAL                                      :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3015,9 +3015,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_bool_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_bool_0d
 
 SUBROUTINE ftg_allocate_and_read_pointer_bool_1d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
-  LOGICAL(KIND=C_BOOL), INTENT(OUT), POINTER :: field(:)
-  LOGICAL                                    :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                 :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(INOUT), POINTER :: field(:)
+  LOGICAL                                      :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3031,9 +3031,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_bool_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_bool_1d
 
 SUBROUTINE ftg_allocate_and_read_pointer_bool_2d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
-  LOGICAL(KIND=C_BOOL), INTENT(OUT), POINTER :: field(:,:)
-  LOGICAL                                    :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                 :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(INOUT), POINTER :: field(:,:)
+  LOGICAL                                      :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3047,9 +3047,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_bool_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_bool_2d
 
 SUBROUTINE ftg_allocate_and_read_pointer_bool_3d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
-  LOGICAL(KIND=C_BOOL), INTENT(OUT), POINTER :: field(:,:,:)
-  LOGICAL                                    :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                 :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(INOUT), POINTER :: field(:,:,:)
+  LOGICAL                                      :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3063,9 +3063,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_bool_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_bool_3d
 
 SUBROUTINE ftg_allocate_and_read_pointer_bool_4d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
-  LOGICAL(KIND=C_BOOL), INTENT(OUT), POINTER :: field(:,:,:,:)
-  LOGICAL                                    :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                 :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(INOUT), POINTER :: field(:,:,:,:)
+  LOGICAL                                      :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3079,9 +3079,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_bool_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_bool_4d
 
 SUBROUTINE ftg_allocate_and_read_pointer_int_0d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
-  INTEGER, INTENT(OUT), POINTER :: field
-  LOGICAL                       :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)    :: fieldname
+  INTEGER, INTENT(INOUT), POINTER :: field
+  LOGICAL                         :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3092,9 +3092,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_int_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_int_0d
 
 SUBROUTINE ftg_allocate_and_read_pointer_int_1d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
-  INTEGER, INTENT(OUT), POINTER :: field(:)
-  LOGICAL                       :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)    :: fieldname
+  INTEGER, INTENT(INOUT), POINTER :: field(:)
+  LOGICAL                         :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3108,9 +3108,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_int_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_int_1d
 
 SUBROUTINE ftg_allocate_and_read_pointer_int_2d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
-  INTEGER, INTENT(OUT), POINTER :: field(:,:)
-  LOGICAL                       :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)    :: fieldname
+  INTEGER, INTENT(INOUT), POINTER :: field(:,:)
+  LOGICAL                         :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3124,9 +3124,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_int_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_int_2d
 
 SUBROUTINE ftg_allocate_and_read_pointer_int_3d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
-  INTEGER, INTENT(OUT), POINTER :: field(:,:,:)
-  LOGICAL                       :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)    :: fieldname
+  INTEGER, INTENT(INOUT), POINTER :: field(:,:,:)
+  LOGICAL                         :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3140,9 +3140,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_int_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_int_3d
 
 SUBROUTINE ftg_allocate_and_read_pointer_int_4d(fieldname, field)
-  CHARACTER(LEN=*)              :: fieldname
-  INTEGER, INTENT(OUT), POINTER :: field(:,:,:,:)
-  LOGICAL                       :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)    :: fieldname
+  INTEGER, INTENT(INOUT), POINTER :: field(:,:,:,:)
+  LOGICAL                         :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3156,9 +3156,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_int_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_int_4d
 
 SUBROUTINE ftg_allocate_and_read_pointer_long_0d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
-  INTEGER(KIND=C_LONG), INTENT(OUT), POINTER :: field
-  LOGICAL                                    :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                 :: fieldname
+  INTEGER(KIND=C_LONG), INTENT(INOUT), POINTER :: field
+  LOGICAL                                      :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3169,9 +3169,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_long_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_long_0d
 
 SUBROUTINE ftg_allocate_and_read_pointer_long_1d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
-  INTEGER(KIND=C_LONG), INTENT(OUT), POINTER :: field(:)
-  LOGICAL                                    :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                 :: fieldname
+  INTEGER(KIND=C_LONG), INTENT(INOUT), POINTER :: field(:)
+  LOGICAL                                      :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3185,9 +3185,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_long_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_long_1d
 
 SUBROUTINE ftg_allocate_and_read_pointer_long_2d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
-  INTEGER(KIND=C_LONG), INTENT(OUT), POINTER :: field(:,:)
-  LOGICAL                                    :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                 :: fieldname
+  INTEGER(KIND=C_LONG), INTENT(INOUT), POINTER :: field(:,:)
+  LOGICAL                                      :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3201,9 +3201,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_long_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_long_2d
 
 SUBROUTINE ftg_allocate_and_read_pointer_long_3d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
-  INTEGER(KIND=C_LONG), INTENT(OUT), POINTER :: field(:,:,:)
-  LOGICAL                                    :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                 :: fieldname
+  INTEGER(KIND=C_LONG), INTENT(INOUT), POINTER :: field(:,:,:)
+  LOGICAL                                      :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3217,9 +3217,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_long_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_long_3d
 
 SUBROUTINE ftg_allocate_and_read_pointer_long_4d(fieldname, field)
-  CHARACTER(LEN=*)                           :: fieldname
-  INTEGER(KIND=C_LONG), INTENT(OUT), POINTER :: field(:,:,:,:)
-  LOGICAL                                    :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                 :: fieldname
+  INTEGER(KIND=C_LONG), INTENT(INOUT), POINTER :: field(:,:,:,:)
+  LOGICAL                                      :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3233,9 +3233,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_long_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_long_4d
 
 SUBROUTINE ftg_allocate_and_read_pointer_float_0d(fieldname, field)
-  CHARACTER(LEN=*)                         :: fieldname
-  REAL(KIND=C_FLOAT), INTENT(OUT), POINTER :: field
-  LOGICAL                                  :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)               :: fieldname
+  REAL(KIND=C_FLOAT), INTENT(INOUT), POINTER :: field
+  LOGICAL                                    :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3246,9 +3246,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_float_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_float_0d
 
 SUBROUTINE ftg_allocate_and_read_pointer_float_1d(fieldname, field)
-  CHARACTER(LEN=*)                         :: fieldname
-  REAL(KIND=C_FLOAT), INTENT(OUT), POINTER :: field(:)
-  LOGICAL                                  :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)               :: fieldname
+  REAL(KIND=C_FLOAT), INTENT(INOUT), POINTER :: field(:)
+  LOGICAL                                    :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3262,9 +3262,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_float_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_float_1d
 
 SUBROUTINE ftg_allocate_and_read_pointer_float_2d(fieldname, field)
-  CHARACTER(LEN=*)                         :: fieldname
-  REAL(KIND=C_FLOAT), INTENT(OUT), POINTER :: field(:,:)
-  LOGICAL                                  :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)               :: fieldname
+  REAL(KIND=C_FLOAT), INTENT(INOUT), POINTER :: field(:,:)
+  LOGICAL                                    :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3278,9 +3278,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_float_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_float_2d
 
 SUBROUTINE ftg_allocate_and_read_pointer_float_3d(fieldname, field)
-  CHARACTER(LEN=*)                         :: fieldname
-  REAL(KIND=C_FLOAT), INTENT(OUT), POINTER :: field(:,:,:)
-  LOGICAL                                  :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)               :: fieldname
+  REAL(KIND=C_FLOAT), INTENT(INOUT), POINTER :: field(:,:,:)
+  LOGICAL                                    :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3294,9 +3294,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_float_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_float_3d
 
 SUBROUTINE ftg_allocate_and_read_pointer_float_4d(fieldname, field)
-  CHARACTER(LEN=*)                         :: fieldname
-  REAL(KIND=C_FLOAT), INTENT(OUT), POINTER :: field(:,:,:,:)
-  LOGICAL                                  :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)               :: fieldname
+  REAL(KIND=C_FLOAT), INTENT(INOUT), POINTER :: field(:,:,:,:)
+  LOGICAL                                    :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3310,9 +3310,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_float_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_float_4d
 
 SUBROUTINE ftg_allocate_and_read_pointer_double_0d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
-  REAL(KIND=C_DOUBLE), INTENT(OUT), POINTER :: field
-  LOGICAL                                   :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                :: fieldname
+  REAL(KIND=C_DOUBLE), INTENT(INOUT), POINTER :: field
+  LOGICAL                                     :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3323,9 +3323,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_double_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_double_0d
 
 SUBROUTINE ftg_allocate_and_read_pointer_double_1d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
-  REAL(KIND=C_DOUBLE), INTENT(OUT), POINTER :: field(:)
-  LOGICAL                                   :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                :: fieldname
+  REAL(KIND=C_DOUBLE), INTENT(INOUT), POINTER :: field(:)
+  LOGICAL                                     :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3339,9 +3339,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_double_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_double_1d
 
 SUBROUTINE ftg_allocate_and_read_pointer_double_2d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
-  REAL(KIND=C_DOUBLE), INTENT(OUT), POINTER :: field(:,:)
-  LOGICAL                                   :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                :: fieldname
+  REAL(KIND=C_DOUBLE), INTENT(INOUT), POINTER :: field(:,:)
+  LOGICAL                                     :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3355,9 +3355,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_double_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_double_2d
 
 SUBROUTINE ftg_allocate_and_read_pointer_double_3d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
-  REAL(KIND=C_DOUBLE), INTENT(OUT), POINTER :: field(:,:,:)
-  LOGICAL                                   :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                :: fieldname
+  REAL(KIND=C_DOUBLE), INTENT(INOUT), POINTER :: field(:,:,:)
+  LOGICAL                                     :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3371,9 +3371,9 @@ SUBROUTINE ftg_allocate_and_read_pointer_double_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_pointer_double_3d
 
 SUBROUTINE ftg_allocate_and_read_pointer_double_4d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
-  REAL(KIND=C_DOUBLE), INTENT(OUT), POINTER :: field(:,:,:,:)
-  LOGICAL                                   :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                :: fieldname
+  REAL(KIND=C_DOUBLE), INTENT(INOUT), POINTER :: field(:,:,:,:)
+  LOGICAL                                     :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ASSOCIATED(field)) THEN
@@ -3390,9 +3390,9 @@ END SUBROUTINE ftg_allocate_and_read_pointer_double_4d
 !=============================================================================
 
 SUBROUTINE ftg_allocate_and_read_allocatable_logical_0d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
-  LOGICAL, INTENT(OUT), ALLOCATABLE, TARGET :: field
-  LOGICAL                                   :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                :: fieldname
+  LOGICAL, INTENT(INOUT), ALLOCATABLE, TARGET :: field
+  LOGICAL                                     :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3403,9 +3403,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_logical_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_logical_0d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_logical_1d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
-  LOGICAL, INTENT(OUT), ALLOCATABLE, TARGET :: field(:)
-  LOGICAL                                   :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                :: fieldname
+  LOGICAL, INTENT(INOUT), ALLOCATABLE, TARGET :: field(:)
+  LOGICAL                                     :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3419,9 +3419,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_logical_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_logical_1d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_logical_2d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
-  LOGICAL, INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:)
-  LOGICAL                                   :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                :: fieldname
+  LOGICAL, INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:)
+  LOGICAL                                     :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3435,9 +3435,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_logical_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_logical_2d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_logical_3d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
-  LOGICAL, INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:,:)
-  LOGICAL                                   :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                :: fieldname
+  LOGICAL, INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:,:)
+  LOGICAL                                     :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3451,9 +3451,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_logical_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_logical_3d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_logical_4d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
-  LOGICAL, INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:,:,:)
-  LOGICAL                                   :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                :: fieldname
+  LOGICAL, INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:,:,:)
+  LOGICAL                                     :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3467,9 +3467,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_logical_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_logical_4d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_bool_0d(fieldname, field)
-  CHARACTER(LEN=*)                                       :: fieldname
-  LOGICAL(KIND=C_BOOL), INTENT(OUT), ALLOCATABLE, TARGET :: field
-  LOGICAL                                                :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                             :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(INOUT), ALLOCATABLE, TARGET :: field
+  LOGICAL                                                  :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3480,9 +3480,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_bool_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_bool_0d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_bool_1d(fieldname, field)
-  CHARACTER(LEN=*)                                       :: fieldname
-  LOGICAL(KIND=C_BOOL), INTENT(OUT), ALLOCATABLE, TARGET :: field(:)
-  LOGICAL                                                :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                             :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:)
+  LOGICAL                                                  :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3496,9 +3496,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_bool_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_bool_1d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_bool_2d(fieldname, field)
-  CHARACTER(LEN=*)                                       :: fieldname
-  LOGICAL(KIND=C_BOOL), INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:)
-  LOGICAL                                                :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                             :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:)
+  LOGICAL                                                  :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3512,9 +3512,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_bool_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_bool_2d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_bool_3d(fieldname, field)
-  CHARACTER(LEN=*)                                       :: fieldname
-  LOGICAL(KIND=C_BOOL), INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:,:)
-  LOGICAL                                                :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                             :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:,:)
+  LOGICAL                                                  :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3528,9 +3528,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_bool_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_bool_3d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_bool_4d(fieldname, field)
-  CHARACTER(LEN=*)                                       :: fieldname
-  LOGICAL(KIND=C_BOOL), INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:,:,:)
-  LOGICAL                                                :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                             :: fieldname
+  LOGICAL(KIND=C_BOOL), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:,:,:)
+  LOGICAL                                                  :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3544,9 +3544,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_bool_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_bool_4d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_int_0d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
-  INTEGER, INTENT(OUT), ALLOCATABLE, TARGET :: field
-  LOGICAL                                   :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                :: fieldname
+  INTEGER, INTENT(INOUT), ALLOCATABLE, TARGET :: field
+  LOGICAL                                     :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3557,9 +3557,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_int_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_int_0d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_int_1d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
-  INTEGER, INTENT(OUT), ALLOCATABLE, TARGET :: field(:)
-  LOGICAL                                   :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                :: fieldname
+  INTEGER, INTENT(INOUT), ALLOCATABLE, TARGET :: field(:)
+  LOGICAL                                     :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3573,9 +3573,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_int_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_int_1d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_int_2d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
-  INTEGER, INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:)
-  LOGICAL                                   :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                :: fieldname
+  INTEGER, INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:)
+  LOGICAL                                     :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3589,9 +3589,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_int_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_int_2d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_int_3d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
-  INTEGER, INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:,:)
-  LOGICAL                                   :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                :: fieldname
+  INTEGER, INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:,:)
+  LOGICAL                                     :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3605,9 +3605,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_int_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_int_3d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_int_4d(fieldname, field)
-  CHARACTER(LEN=*)                          :: fieldname
-  INTEGER, INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:,:,:)
-  LOGICAL                                   :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                :: fieldname
+  INTEGER, INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:,:,:)
+  LOGICAL                                     :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3621,9 +3621,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_int_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_int_4d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_long_0d(fieldname, field)
-  CHARACTER(LEN=*)                                       :: fieldname
-  INTEGER(KIND=C_LONG), INTENT(OUT), ALLOCATABLE, TARGET :: field
-  LOGICAL                                                :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                             :: fieldname
+  INTEGER(KIND=C_LONG), INTENT(INOUT), ALLOCATABLE, TARGET :: field
+  LOGICAL                                                  :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3634,9 +3634,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_long_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_long_0d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_long_1d(fieldname, field)
-  CHARACTER(LEN=*)                                       :: fieldname
-  INTEGER(KIND=C_LONG), INTENT(OUT), ALLOCATABLE, TARGET :: field(:)
-  LOGICAL                                                :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                             :: fieldname
+  INTEGER(KIND=C_LONG), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:)
+  LOGICAL                                                  :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3650,9 +3650,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_long_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_long_1d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_long_2d(fieldname, field)
-  CHARACTER(LEN=*)                                       :: fieldname
-  INTEGER(KIND=C_LONG), INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:)
-  LOGICAL                                                :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                             :: fieldname
+  INTEGER(KIND=C_LONG), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:)
+  LOGICAL                                                  :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3666,9 +3666,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_long_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_long_2d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_long_3d(fieldname, field)
-  CHARACTER(LEN=*)                                       :: fieldname
-  INTEGER(KIND=C_LONG), INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:,:)
-  LOGICAL                                                :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                             :: fieldname
+  INTEGER(KIND=C_LONG), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:,:)
+  LOGICAL                                                  :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3682,9 +3682,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_long_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_long_3d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_long_4d(fieldname, field)
-  CHARACTER(LEN=*)                                       :: fieldname
-  INTEGER(KIND=C_LONG), INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:,:,:)
-  LOGICAL                                                :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                             :: fieldname
+  INTEGER(KIND=C_LONG), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:,:,:)
+  LOGICAL                                                  :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3698,9 +3698,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_long_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_long_4d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_float_0d(fieldname, field)
-  CHARACTER(LEN=*)                                     :: fieldname
-  REAL(KIND=C_FLOAT), INTENT(OUT), ALLOCATABLE, TARGET :: field
-  LOGICAL                                              :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                           :: fieldname
+  REAL(KIND=C_FLOAT), INTENT(INOUT), ALLOCATABLE, TARGET :: field
+  LOGICAL                                                :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3711,9 +3711,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_float_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_float_0d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_float_1d(fieldname, field)
-  CHARACTER(LEN=*)                                     :: fieldname
-  REAL(KIND=C_FLOAT), INTENT(OUT), ALLOCATABLE, TARGET :: field(:)
-  LOGICAL                                              :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                           :: fieldname
+  REAL(KIND=C_FLOAT), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:)
+  LOGICAL                                                :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3727,9 +3727,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_float_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_float_1d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_float_2d(fieldname, field)
-  CHARACTER(LEN=*)                                     :: fieldname
-  REAL(KIND=C_FLOAT), INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:)
-  LOGICAL                                              :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                           :: fieldname
+  REAL(KIND=C_FLOAT), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:)
+  LOGICAL                                                :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3743,9 +3743,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_float_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_float_2d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_float_3d(fieldname, field)
-  CHARACTER(LEN=*)                                     :: fieldname
-  REAL(KIND=C_FLOAT), INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:,:)
-  LOGICAL                                              :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                           :: fieldname
+  REAL(KIND=C_FLOAT), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:,:)
+  LOGICAL                                                :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3759,9 +3759,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_float_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_float_3d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_float_4d(fieldname, field)
-  CHARACTER(LEN=*)                                     :: fieldname
-  REAL(KIND=C_FLOAT), INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:,:,:)
-  LOGICAL                                              :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                           :: fieldname
+  REAL(KIND=C_FLOAT), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:,:,:)
+  LOGICAL                                                :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3775,9 +3775,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_float_4d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_float_4d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_double_0d(fieldname, field)
-  CHARACTER(LEN=*)                                      :: fieldname
-  REAL(KIND=C_DOUBLE), INTENT(OUT), ALLOCATABLE, TARGET :: field
-  LOGICAL                                               :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                            :: fieldname
+  REAL(KIND=C_DOUBLE), INTENT(INOUT), ALLOCATABLE, TARGET :: field
+  LOGICAL                                                 :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3788,9 +3788,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_double_0d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_double_0d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_double_1d(fieldname, field)
-  CHARACTER(LEN=*)                                      :: fieldname
-  REAL(KIND=C_DOUBLE), INTENT(OUT), ALLOCATABLE, TARGET :: field(:)
-  LOGICAL                                               :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                            :: fieldname
+  REAL(KIND=C_DOUBLE), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:)
+  LOGICAL                                                 :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3804,9 +3804,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_double_1d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_double_1d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_double_2d(fieldname, field)
-  CHARACTER(LEN=*)                                      :: fieldname
-  REAL(KIND=C_DOUBLE), INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:)
-  LOGICAL                                               :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                            :: fieldname
+  REAL(KIND=C_DOUBLE), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:)
+  LOGICAL                                                 :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3820,9 +3820,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_double_2d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_double_2d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_double_3d(fieldname, field)
-  CHARACTER(LEN=*)                                      :: fieldname
-  REAL(KIND=C_DOUBLE), INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:,:)
-  LOGICAL                                               :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                            :: fieldname
+  REAL(KIND=C_DOUBLE), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:,:)
+  LOGICAL                                                 :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN
@@ -3836,9 +3836,9 @@ SUBROUTINE ftg_allocate_and_read_allocatable_double_3d(fieldname, field)
 END SUBROUTINE ftg_allocate_and_read_allocatable_double_3d
 
 SUBROUTINE ftg_allocate_and_read_allocatable_double_4d(fieldname, field)
-  CHARACTER(LEN=*)                                      :: fieldname
-  REAL(KIND=C_DOUBLE), INTENT(OUT), ALLOCATABLE, TARGET :: field(:,:,:,:)
-  LOGICAL                                               :: registered_only
+  CHARACTER(LEN=*), INTENT(IN)                            :: fieldname
+  REAL(KIND=C_DOUBLE), INTENT(INOUT), ALLOCATABLE, TARGET :: field(:,:,:,:)
+  LOGICAL                                                 :: registered_only
 
   IF (.NOT. ignore_not_existing .OR. ftg_field_exists(fieldname)) THEN
     IF (.NOT. ALLOCATED(field)) THEN

--- a/test/serialbox-fortran/ser_ftg_test.pf
+++ b/test/serialbox-fortran/ser_ftg_test.pf
@@ -869,7 +869,7 @@ CONTAINS
 @Test
     SUBROUTINE testAllocateAndRead()
     
-      CHARACTER(len=*), PARAMETER :: base_name = 'testIntegerArrays'
+      CHARACTER(len=*), PARAMETER :: base_name = 'testAllocateAndRead'
     
       INTEGER :: w_testfield_i0, w_testfield_i1(5), w_testfield_i2(4,3), w_testfield_i3(3,2,2), w_testfield_i4(2,2,2,2)
       INTEGER, POINTER :: rp_testfield_i0 => NULL(), rp_testfield_i1(:) => NULL(), rp_testfield_i2(:,:) => NULL(), &
@@ -892,16 +892,6 @@ CONTAINS
       CALL ftg_destroy_serializer()
       
       CALL ftg_set_serializer(dir, base_name, 'r')
-      @assertTrue(ftg_field_exists("testfield_i0"))
-      @assertTrue(ftg_field_exists("testfield_i1"))
-      @assertTrue(ftg_field_exists("testfield_i2"))
-      @assertTrue(ftg_field_exists("testfield_i3"))
-      @assertTrue(ftg_field_exists("testfield_i4"))
-      @assertEqual(exp_size_scalar, fs_get_size(ftg_get_serializer(), "testfield_i0"))
-      @assertEqual(exp_size(SHAPE(w_testfield_i1)), fs_get_size(ftg_get_serializer(), "testfield_i1"))
-      @assertEqual(exp_size(SHAPE(w_testfield_i2)), fs_get_size(ftg_get_serializer(), "testfield_i2"))
-      @assertEqual(exp_size(SHAPE(w_testfield_i3)), fs_get_size(ftg_get_serializer(), "testfield_i3"))
-      @assertEqual(exp_size(SHAPE(w_testfield_i4)), fs_get_size(ftg_get_serializer(), "testfield_i4"))
       CALL ftg_allocate_and_read_pointer("testfield_i0", rp_testfield_i0)
       CALL ftg_allocate_and_read_pointer("testfield_i1", rp_testfield_i1)
       CALL ftg_allocate_and_read_pointer("testfield_i2", rp_testfield_i2)
@@ -926,6 +916,57 @@ CONTAINS
       @assertEqual(w_testfield_i4, ra_testfield_i4)
     
     END SUBROUTINE testAllocateAndRead
+
+@Test
+    SUBROUTINE testReallocateAndRead()
+    
+      CHARACTER(len=*), PARAMETER :: base_name = 'testReallocateAndRead'
+    
+      INTEGER :: w_testfield_i1(5), w_testfield_i2(4,3), w_testfield_i3(3,2,2), w_testfield_i4(2,2,2,2)
+      INTEGER, POINTER :: rp_testfield_i1(:), rp_testfield_i2(:,:), rp_testfield_i3(:,:,:), rp_testfield_i4(:,:,:,:)
+      INTEGER, ALLOCATABLE :: ra_testfield_i1(:), ra_testfield_i2(:,:), ra_testfield_i3(:,:,:), ra_testfield_i4(:,:,:,:)
+      
+      w_testfield_i1 = (/ 0, 1, 2, 3, 4 /)
+      w_testfield_i2 = RESHAPE((/ 0, 3, 2, 9, 1, 4, 7, 10, 2, 5, 8, 11 /), SHAPE(w_testfield_i2))
+      w_testfield_i3 = RESHAPE((/ 0, 4, 8, 2, 6, 10, 1, 5, 9, 3, 7, 11 /), SHAPE(w_testfield_i3))
+      w_testfield_i4 = RESHAPE((/ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 /), SHAPE(w_testfield_i4))
+            
+      CALL ftg_set_serializer(dir, base_name, 'w')
+      CALL ftg_write("testfield_i1", w_testfield_i1, LBOUND(w_testfield_i1), UBOUND(w_testfield_i1))
+      CALL ftg_write("testfield_i2", w_testfield_i2, LBOUND(w_testfield_i2), UBOUND(w_testfield_i2))
+      CALL ftg_write("testfield_i3", w_testfield_i3, LBOUND(w_testfield_i3), UBOUND(w_testfield_i3))
+      CALL ftg_write("testfield_i4", w_testfield_i4, LBOUND(w_testfield_i4), UBOUND(w_testfield_i4))
+      CALL ftg_destroy_serializer()
+      
+      ALLOCATE(rp_testfield_i1(42))
+      ALLOCATE(rp_testfield_i3(3, 2, 42))
+      
+      ALLOCATE(ra_testfield_i1(42))
+      ALLOCATE(ra_testfield_i2(3, 4))
+      ALLOCATE(ra_testfield_i3(3, 2, 2))
+      ALLOCATE(ra_testfield_i4(2, 2, 2, 0))
+      
+      CALL ftg_set_serializer(dir, base_name, 'r')
+      CALL ftg_allocate_and_read_pointer("testfield_i1", rp_testfield_i1)
+      CALL ftg_allocate_and_read_pointer("testfield_i2", rp_testfield_i2)
+      CALL ftg_allocate_and_read_pointer("testfield_i3", rp_testfield_i3)
+      CALL ftg_allocate_and_read_pointer("testfield_i4", rp_testfield_i4)
+      CALL ftg_allocate_and_read_allocatable("testfield_i1", ra_testfield_i1)
+      CALL ftg_allocate_and_read_allocatable("testfield_i2", ra_testfield_i2)
+      CALL ftg_allocate_and_read_allocatable("testfield_i3", ra_testfield_i3)
+      CALL ftg_allocate_and_read_allocatable("testfield_i4", ra_testfield_i4)
+      CALL ftg_destroy_serializer()
+      
+      @assertEqual(w_testfield_i1, rp_testfield_i1)
+      @assertEqual(w_testfield_i2, rp_testfield_i2)
+      @assertEqual(w_testfield_i3, rp_testfield_i3)
+      @assertEqual(w_testfield_i4, rp_testfield_i4)
+      @assertEqual(w_testfield_i1, ra_testfield_i1)
+      @assertEqual(w_testfield_i2, ra_testfield_i2)
+      @assertEqual(w_testfield_i3, ra_testfield_i3)
+      @assertEqual(w_testfield_i4, ra_testfield_i4)
+    
+    END SUBROUTINE testReallocateAndRead
 
 
 @Test


### PR DESCRIPTION
The FTG functions `ftg_allocate_and_read_*` now reallocate already allocated pointers and allocatables when current shapes do not match to stored sizes.

Should also help with never initialised pointers for which `ASSOCIATED()` arbitrarily returns true.