### PR TITLE
Fix compilation for Intel

### DIFF
--- a/src/serialbox/core/frontend/stella/Serializer.cpp
+++ b/src/serialbox/core/frontend/stella/Serializer.cpp
@@ -16,7 +16,6 @@
 #include "serialbox/core/SerializerImpl.h"
 #include "serialbox/core/Unreachable.h"
 #include "serialbox/core/frontend/stella/Utility.h"
-#include <boost/make_shared.hpp>
 #include <cstdlib>
 
 namespace serialbox {
@@ -61,15 +60,15 @@ void Serializer::Init(const std::string& directory, const std::string& prefix,
     switch(mode) {
     case SerializerOpenModeRead:
       serializerImpl_ =
-          boost::make_shared<SerializerImpl>(OpenModeKind::Read, directory, prefix, "Binary");
+          std::make_shared<SerializerImpl>(OpenModeKind::Read, directory, prefix, "Binary");
       break;
     case SerializerOpenModeWrite:
       serializerImpl_ =
-          boost::make_shared<SerializerImpl>(OpenModeKind::Write, directory, prefix, "Binary");
+          std::make_shared<SerializerImpl>(OpenModeKind::Write, directory, prefix, "Binary");
       break;
     case SerializerOpenModeAppend:
       serializerImpl_ =
-          boost::make_shared<SerializerImpl>(OpenModeKind::Append, directory, prefix, "Binary");
+          std::make_shared<SerializerImpl>(OpenModeKind::Append, directory, prefix, "Binary");
       break;
     }
   } catch(Exception& e) {

--- a/src/serialbox/core/frontend/stella/Serializer.h
+++ b/src/serialbox/core/frontend/stella/Serializer.h
@@ -26,11 +26,11 @@
 #include "serialbox/core/frontend/stella/MetainfoSet.h"
 #include "serialbox/core/frontend/stella/Savepoint.h"
 #include "serialbox/core/frontend/stella/SerializationException.h"
-#include <boost/shared_ptr.hpp>
 #include <map>
 #include <sstream>
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace serialbox {
 
@@ -290,12 +290,12 @@ public:
   std::string ToString() const;
 
   /// \brief Get implementation pointer
-  boost::shared_ptr<SerializerImpl>& getImpl() { return serializerImpl_; }
-  const boost::shared_ptr<SerializerImpl>& getImpl() const { return serializerImpl_; }
+  std::shared_ptr<SerializerImpl>& getImpl() { return serializerImpl_; }
+  const std::shared_ptr<SerializerImpl>& getImpl() const { return serializerImpl_; }
 
 private:
   // Implementation pointer
-  boost::shared_ptr<SerializerImpl> serializerImpl_;
+  std::shared_ptr<SerializerImpl> serializerImpl_;
 
   // These data-strucures allow to return refrences but do not actually own any data but they need
   // to be kept in sync with the data from serializerImpl!


### PR DESCRIPTION
Following commit is fixing a compilation error with Intel compiler. The changes are using `std::shared_ptr` instead of `boost::shared_ptr`

Used compiler: intel 18.0.1
Boost version: 1.54.0

Error was:

    /tmp/nawd/serialbox2/src/serialbox/core/frontend/stella/Serializer.cpp(28): error: no operator "=" matches these operands
                operand types are: boost::shared_ptr<serialbox::SerializerImpl> = std::nullptr_t
      Serializer::Serializer() { serializerImpl_ = nullptr; }
                                             ^
    compilation aborted for /tmp/nawd/serialbox2/src/serialbox/core/frontend/stella/Serializer.cpp (code 2)
    src/serialbox/core/CMakeFiles/SerialboxObjects.dir/build.make:400: recipe for target 'src/serialbox/core/CMakeFiles/SerialboxObjects.dir/frontend/stella/Serializer.cpp.o' failed