### PR TITLE
Fix for Intel compiler: remove pointless init of boost::shared_ptr

### DIFF
--- a/src/serialbox/core/frontend/stella/Serializer.cpp
+++ b/src/serialbox/core/frontend/stella/Serializer.cpp
@@ -25,7 +25,7 @@ namespace stella {
 
 int Serializer::enabled_ = 0;
 
-Serializer::Serializer() { serializerImpl_ = nullptr; }
+Serializer::Serializer() {}
 
 SerializerOpenMode Serializer::mode() const {
   switch(serializerImpl_->mode()) {


### PR DESCRIPTION
Fixes problem with intel compiler, see #192.