### PR TITLE
C: Don't write json in read mode

### DIFF
--- a/src/serialbox-c/Serializer.cpp
+++ b/src/serialbox-c/Serializer.cpp
@@ -53,7 +53,7 @@ std::vector<int> make_dims(int iSize, int jSize, int kSize, int lSize) {
     dims.push_back(lSize);
   return dims;
 }
-}
+} // namespace
 
 /*===------------------------------------------------------------------------------------------===*\
  *     Construction & Destruction
@@ -89,7 +89,8 @@ serialboxSerializer_t* serialboxSerializerCreate(int mode, const char* directory
 
 void serialboxSerializerDestroy(serialboxSerializer_t* serializer) {
   if(serializer) {
-    serialboxSerializerUpdateMetaData(serializer);
+    if(serialboxSerializerGetMode(serializer) != Read)
+      serialboxSerializerUpdateMetaData(serializer);
     Serializer* ser = toSerializer(serializer);
     if(serializer->ownsData)
       delete ser;

--- a/src/serialbox-python/serialbox/core.py
+++ b/src/serialbox-python/serialbox/core.py
@@ -75,11 +75,4 @@ class Config(object):
     def __repr__(self):
         return "<Config {0}>".format(self.instance.compile_options)
 
-def init_serialbox():
-    """Initialize the SerialboxC library by installing the error handler.
-    """
-    lib.serialboxInstallFatalErrorHandler(lib.serialboxStateErrorHandler)
-
-
 register_library(lib)
-init_serialbox()

--- a/src/serialbox/core/SerializerImpl.cpp
+++ b/src/serialbox/core/SerializerImpl.cpp
@@ -390,6 +390,9 @@ std::ostream& operator<<(std::ostream& stream, const SerializerImpl& s) {
 void SerializerImpl::updateMetaData() {
   LOG(info) << "Update MetaData of Serializer";
 
+  if(mode_ == OpenModeKind::Read)
+    throw Exception("Trying to write meta data in Read mode.");
+
   json::json jsonNode = *this;
 
   // Write metaData to disk (just overwrite the file, we assume that there is never more than one


### PR DESCRIPTION
Fixes #194, fixes #151 

Additional changes:
Use the default error handler from python.
