### PR TITLE
[FTG] Bug fix in ftg_cmp_print_deviations_*

### DIFF
--- a/src/serialbox-fortran/m_ser_ftg_cmp.f90
+++ b/src/serialbox-fortran/m_ser_ftg_cmp.f90
@@ -582,10 +582,12 @@ SUBROUTINE ftg_cmp_print_deviations_int_1d(expected, actual, fieldname_print, lb
   INTEGER, INTENT(IN), OPTIONAL :: lbounds(1)
   LOGICAL, ALLOCATABLE          :: mask(:)
   INTEGER, ALLOCATABLE          :: deltas(:)
-  INTEGER                       :: indices(1), indexAdj(1), i, j
+  INTEGER                       :: indices(1), indexAdj(1), expLbounds(1), expUbounds(1), i, j
   
   mask = actual /= expected
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -616,10 +618,12 @@ SUBROUTINE ftg_cmp_print_deviations_int_2d(expected, actual, fieldname_print, lb
   INTEGER, INTENT(IN), OPTIONAL :: lbounds(2)
   LOGICAL, ALLOCATABLE          :: mask(:,:)
   INTEGER, ALLOCATABLE          :: deltas(:,:)
-  INTEGER                       :: indices(2), indexAdj(2), i, j
+  INTEGER                       :: indices(2), indexAdj(2), expLbounds(2), expUbounds(2), i, j
   
   mask = actual /= expected
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1), expLbounds(2):expUbounds(2)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -652,10 +656,12 @@ SUBROUTINE ftg_cmp_print_deviations_int_3d(expected, actual, fieldname_print, lb
   INTEGER, INTENT(IN), OPTIONAL :: lbounds(3)
   LOGICAL, ALLOCATABLE          :: mask(:,:,:)
   INTEGER, ALLOCATABLE          :: deltas(:,:,:)
-  INTEGER                       :: indices(3), indexAdj(3), i, j
+  INTEGER                       :: indices(3), indexAdj(3), expLbounds(3), expUbounds(3), i, j
   
   mask = actual /= expected
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1), expLbounds(2):expUbounds(2), expLbounds(3):expUbounds(3)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -690,10 +696,12 @@ SUBROUTINE ftg_cmp_print_deviations_int_4d(expected, actual, fieldname_print, lb
   INTEGER, INTENT(IN), OPTIONAL :: lbounds(4)
   LOGICAL, ALLOCATABLE          :: mask(:,:,:,:)
   INTEGER, ALLOCATABLE          :: deltas(:,:,:,:)
-  INTEGER                       :: indices(4), indexAdj(4), i, j
+  INTEGER                       :: indices(4), indexAdj(4), expLbounds(4), expUbounds(4), i, j
   
   mask = actual /= expected
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1), expLbounds(2):expUbounds(2), expLbounds(3):expUbounds(3), expLbounds(4):expUbounds(4)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -730,10 +738,12 @@ SUBROUTINE ftg_cmp_print_deviations_long_1d(expected, actual, fieldname_print, l
   INTEGER, INTENT(IN), OPTIONAL     :: lbounds(1)
   LOGICAL, ALLOCATABLE              :: mask(:)
   INTEGER(KIND=C_LONG), ALLOCATABLE :: deltas(:)
-  INTEGER                           :: indices(1), indexAdj(1), i, j
+  INTEGER                           :: indices(1), indexAdj(1), expLbounds(1), expUbounds(1), i, j
   
   mask = actual /= expected
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -764,10 +774,12 @@ SUBROUTINE ftg_cmp_print_deviations_long_2d(expected, actual, fieldname_print, l
   INTEGER, INTENT(IN), OPTIONAL     :: lbounds(2)
   LOGICAL, ALLOCATABLE              :: mask(:,:)
   INTEGER(KIND=C_LONG), ALLOCATABLE :: deltas(:,:)
-  INTEGER                           :: indices(2), indexAdj(2), i, j
+  INTEGER                           :: indices(2), indexAdj(2), expLbounds(2), expUbounds(2), i, j
   
   mask = actual /= expected
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1), expLbounds(2):expUbounds(2)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -800,10 +812,12 @@ SUBROUTINE ftg_cmp_print_deviations_long_3d(expected, actual, fieldname_print, l
   INTEGER, INTENT(IN), OPTIONAL     :: lbounds(3)
   LOGICAL, ALLOCATABLE              :: mask(:,:,:)
   INTEGER(KIND=C_LONG), ALLOCATABLE :: deltas(:,:,:)
-  INTEGER                           :: indices(3), indexAdj(3), i, j
+  INTEGER                           :: indices(3), indexAdj(3), expLbounds(3), expUbounds(3), i, j
   
   mask = actual /= expected
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1), expLbounds(2):expUbounds(2), expLbounds(3):expUbounds(3)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -838,10 +852,12 @@ SUBROUTINE ftg_cmp_print_deviations_long_4d(expected, actual, fieldname_print, l
   INTEGER, INTENT(IN), OPTIONAL     :: lbounds(4)
   LOGICAL, ALLOCATABLE              :: mask(:,:,:,:)
   INTEGER(KIND=C_LONG), ALLOCATABLE :: deltas(:,:,:,:)
-  INTEGER                           :: indices(4), indexAdj(4), i, j
+  INTEGER                           :: indices(4), indexAdj(4), expLbounds(4), expUbounds(4), i, j
   
   mask = actual /= expected
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1), expLbounds(2):expUbounds(2), expLbounds(3):expUbounds(3), expLbounds(4):expUbounds(4)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -878,12 +894,14 @@ SUBROUTINE ftg_cmp_print_deviations_float_1d(expected, actual, fieldname_print, 
   INTEGER, INTENT(IN), OPTIONAL   :: lbounds(1)
   LOGICAL, ALLOCATABLE            :: mask(:)
   REAL(KIND=C_FLOAT), ALLOCATABLE :: deltas(:)
-  INTEGER                         :: indices(1), indexAdj(1), i, j
+  INTEGER                         :: indices(1), indexAdj(1), expLbounds(1), expUbounds(1), i, j
   REAL, INTENT(in)                :: t
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -914,12 +932,14 @@ SUBROUTINE ftg_cmp_print_deviations_float_2d(expected, actual, fieldname_print, 
   INTEGER, INTENT(IN), OPTIONAL   :: lbounds(2)
   LOGICAL, ALLOCATABLE            :: mask(:,:)
   REAL(KIND=C_FLOAT), ALLOCATABLE :: deltas(:,:)
-  INTEGER                         :: indices(2), indexAdj(2), i, j
+  INTEGER                         :: indices(2), indexAdj(2), expLbounds(2), expUbounds(2), i, j
   REAL, INTENT(in)                :: t
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1), expLbounds(2):expUbounds(2)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -952,12 +972,14 @@ SUBROUTINE ftg_cmp_print_deviations_float_3d(expected, actual, fieldname_print, 
   INTEGER, INTENT(IN), OPTIONAL   :: lbounds(3)
   LOGICAL, ALLOCATABLE            :: mask(:,:,:)
   REAL(KIND=C_FLOAT), ALLOCATABLE :: deltas(:,:,:)
-  INTEGER                         :: indices(3), indexAdj(3), i, j
+  INTEGER                         :: indices(3), indexAdj(3), expLbounds(3), expUbounds(3), i, j
   REAL, INTENT(in)                :: t
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1), expLbounds(2):expUbounds(2), expLbounds(3):expUbounds(3)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -992,12 +1014,14 @@ SUBROUTINE ftg_cmp_print_deviations_float_4d(expected, actual, fieldname_print, 
   INTEGER, INTENT(IN), OPTIONAL   :: lbounds(4)
   LOGICAL, ALLOCATABLE            :: mask(:,:,:,:)
   REAL(KIND=C_FLOAT), ALLOCATABLE :: deltas(:,:,:,:)
-  INTEGER                         :: indices(4), indexAdj(4), i, j
+  INTEGER                         :: indices(4), indexAdj(4), expLbounds(4), expUbounds(4), i, j
   REAL, INTENT(in)                :: t
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1), expLbounds(2):expUbounds(2), expLbounds(3):expUbounds(3), expLbounds(4):expUbounds(4)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -1034,12 +1058,14 @@ SUBROUTINE ftg_cmp_print_deviations_double_1d(expected, actual, fieldname_print,
   INTEGER, INTENT(IN), OPTIONAL    :: lbounds(1)
   LOGICAL, ALLOCATABLE             :: mask(:)
   REAL(KIND=C_DOUBLE), ALLOCATABLE :: deltas(:)
-  INTEGER                          :: indices(1), indexAdj(1), i, j
+  INTEGER                          :: indices(1), indexAdj(1), expLbounds(1), expUbounds(1), i, j
   REAL, INTENT(in)                 :: t
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -1070,12 +1096,14 @@ SUBROUTINE ftg_cmp_print_deviations_double_2d(expected, actual, fieldname_print,
   INTEGER, INTENT(IN), OPTIONAL    :: lbounds(2)
   LOGICAL, ALLOCATABLE             :: mask(:,:)
   REAL(KIND=C_DOUBLE), ALLOCATABLE :: deltas(:,:)
-  INTEGER                          :: indices(2), indexAdj(2), i, j
+  INTEGER                          :: indices(2), indexAdj(2), expLbounds(2), expUbounds(2), i, j
   REAL, INTENT(in)                 :: t
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1), expLbounds(2):expUbounds(2)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -1108,12 +1136,14 @@ SUBROUTINE ftg_cmp_print_deviations_double_3d(expected, actual, fieldname_print,
   INTEGER, INTENT(IN), OPTIONAL    :: lbounds(3)
   LOGICAL, ALLOCATABLE             :: mask(:,:,:)
   REAL(KIND=C_DOUBLE), ALLOCATABLE :: deltas(:,:,:)
-  INTEGER                          :: indices(3), indexAdj(3), i, j
+  INTEGER                          :: indices(3), indexAdj(3), expLbounds(3), expUbounds(3), i, j
   REAL, INTENT(in)                 :: t
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1), expLbounds(2):expUbounds(2), expLbounds(3):expUbounds(3)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -1148,12 +1178,14 @@ SUBROUTINE ftg_cmp_print_deviations_double_4d(expected, actual, fieldname_print,
   INTEGER, INTENT(IN), OPTIONAL    :: lbounds(4)
   LOGICAL, ALLOCATABLE             :: mask(:,:,:,:)
   REAL(KIND=C_DOUBLE), ALLOCATABLE :: deltas(:,:,:,:)
-  INTEGER                          :: indices(4), indexAdj(4), i, j
+  INTEGER                          :: indices(4), indexAdj(4), expLbounds(4), expUbounds(4), i, j
   REAL, INTENT(in)                 :: t
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
-  ALLOCATE(deltas, MOLD=expected)
+  expLbounds = LBOUND(expected)
+  expUbounds = UBOUND(expected)
+  ALLOCATE(deltas(expLbounds(1):expUbounds(1), expLbounds(2):expUbounds(2), expLbounds(3):expUbounds(3), expLbounds(4):expUbounds(4)))
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds

--- a/src/serialbox-fortran/m_ser_ftg_cmp.f90
+++ b/src/serialbox-fortran/m_ser_ftg_cmp.f90
@@ -585,6 +585,7 @@ SUBROUTINE ftg_cmp_print_deviations_int_1d(expected, actual, fieldname_print, lb
   INTEGER                       :: indices(1), indexAdj(1), i, j
   
   mask = actual /= expected
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -618,6 +619,7 @@ SUBROUTINE ftg_cmp_print_deviations_int_2d(expected, actual, fieldname_print, lb
   INTEGER                       :: indices(2), indexAdj(2), i, j
   
   mask = actual /= expected
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -653,6 +655,7 @@ SUBROUTINE ftg_cmp_print_deviations_int_3d(expected, actual, fieldname_print, lb
   INTEGER                       :: indices(3), indexAdj(3), i, j
   
   mask = actual /= expected
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -690,6 +693,7 @@ SUBROUTINE ftg_cmp_print_deviations_int_4d(expected, actual, fieldname_print, lb
   INTEGER                       :: indices(4), indexAdj(4), i, j
   
   mask = actual /= expected
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -729,6 +733,7 @@ SUBROUTINE ftg_cmp_print_deviations_long_1d(expected, actual, fieldname_print, l
   INTEGER                           :: indices(1), indexAdj(1), i, j
   
   mask = actual /= expected
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -762,6 +767,7 @@ SUBROUTINE ftg_cmp_print_deviations_long_2d(expected, actual, fieldname_print, l
   INTEGER                           :: indices(2), indexAdj(2), i, j
   
   mask = actual /= expected
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -797,6 +803,7 @@ SUBROUTINE ftg_cmp_print_deviations_long_3d(expected, actual, fieldname_print, l
   INTEGER                           :: indices(3), indexAdj(3), i, j
   
   mask = actual /= expected
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -834,6 +841,7 @@ SUBROUTINE ftg_cmp_print_deviations_long_4d(expected, actual, fieldname_print, l
   INTEGER                           :: indices(4), indexAdj(4), i, j
   
   mask = actual /= expected
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -875,6 +883,7 @@ SUBROUTINE ftg_cmp_print_deviations_float_1d(expected, actual, fieldname_print, 
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -910,6 +919,7 @@ SUBROUTINE ftg_cmp_print_deviations_float_2d(expected, actual, fieldname_print, 
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -947,6 +957,7 @@ SUBROUTINE ftg_cmp_print_deviations_float_3d(expected, actual, fieldname_print, 
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -986,6 +997,7 @@ SUBROUTINE ftg_cmp_print_deviations_float_4d(expected, actual, fieldname_print, 
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -1027,6 +1039,7 @@ SUBROUTINE ftg_cmp_print_deviations_double_1d(expected, actual, fieldname_print,
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -1062,6 +1075,7 @@ SUBROUTINE ftg_cmp_print_deviations_double_2d(expected, actual, fieldname_print,
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -1099,6 +1113,7 @@ SUBROUTINE ftg_cmp_print_deviations_double_3d(expected, actual, fieldname_print,
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds
@@ -1138,6 +1153,7 @@ SUBROUTINE ftg_cmp_print_deviations_double_4d(expected, actual, fieldname_print,
   
   
   mask = .NOT. (actual /= actual .AND. expected /= expected) .AND. ABS(actual - expected) > t
+  ALLOCATE(deltas, MOLD=expected)
   deltas = ABS(expected - actual)
   IF (PRESENT(lbounds)) THEN
     indexAdj = lbounds


### PR DESCRIPTION
Added a missing `ALLOCATE` of the `delta` variable in the `ftg_cmp_print_deviations_*` subroutines in the `m_ser_ftg_cmp` module. I don't know exactly why this is needed and the `mask` variable in line above doesn't need it, but anyway...

The module was generated from this file: [m_ser_ftg_cmp.f90.cht](https://github.com/chovyy/fortrangenerictor/blob/master/m_ser_ftg_cmp.f90.cht).