### PR TITLE
[C] Respect zero size dimensions

### DIFF
--- a/src/serialbox-c/Serializer.cpp
+++ b/src/serialbox-c/Serializer.cpp
@@ -43,11 +43,11 @@ static std::string vecToString(VecType&& vec) {
 
 std::vector<int> make_dims(int iSize, int jSize, int kSize, int lSize) {
   std::vector<int> dims;
-  if(iSize > 0)
+  if(iSize > 0 or jSize > 0 or kSize > 0 or lSize > 0)
     dims.push_back(iSize);
-  if(jSize > 0)
+  if(jSize > 0 or kSize > 0 or lSize > 0)
     dims.push_back(jSize);
-  if(kSize > 0)
+  if(kSize > 0 or lSize > 0)
     dims.push_back(kSize);
   if(lSize > 0)
     dims.push_back(lSize);


### PR DESCRIPTION
Currently, when you register a zero-sized array with the Fortran or C interface the zero dimensions are left out in the `dims` meta-info. So, even if you know the actual rank, you don't know which dimension is the zero one. Arrays with dimensions (0,4,2), (4,0,2) and (4,2,0) all become `"dims": [4, 2]`. 
I have made a little change to the make_dims function, so that (0,4,2) becomes `"dims": [0, 4, 2]`, (4,0,2) becomes `"dims": [4, 0, 2]` and (4,2,0) stays `"dims": [4, 2]`. 
That's not perfect, but a small improvement.