### PR TITLE
Modifications to allow Serialbox to be used in CMake superbuild projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,11 @@ cmake_minimum_required(VERSION 3.9.0)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_C_EXTENSIONS OFF)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
 include(ExternalProject)
 include(CMakeParseArguments)
 include(CheckCXXCompilerFlag)
+include(SerialboxInstallTargets)
 
 #---------------------------------------- Configure ------------------------------------------------
 
@@ -100,11 +101,13 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 
 # Clear all cmake generated files
-add_custom_target(clean-all
-                  COMMAND ${CMAKE_MAKE_PROGRAM} clean
-                  COMMAND ${CMAKE_COMMAND} -P  
-                  "${CMAKE_SOURCE_DIR}/cmake/modules/SerialboxCleanAll.cmake")
-                  
+if( NOT TARGET clean-all )
+  add_custom_target(clean-all
+                    COMMAND ${CMAKE_MAKE_PROGRAM} clean
+                    COMMAND ${CMAKE_COMMAND} -P  
+                    "${PROJECT_SOURCE_DIR}/cmake/modules/SerialboxCleanAll.cmake")
+endif()
+
 # We need thread support
 find_package(Threads REQUIRED)
 
@@ -216,6 +219,7 @@ if(${SERIALBOX_USE_NETCDF})
     message(FATAL_ERROR "NetCDF library not found!")
   endif()
   set(SERIALBOX_HAS_NETCDF 1)
+  serialbox_install_targets( TARGETS NETCDF_TARGET )
 endif()
 
 #---------------------------------------- Python ---------------------------------------------------
@@ -281,9 +285,7 @@ if(_use_boost_filesystem)
     set(SERIALBOX_FILESYSTEM_LIBRARY_STRING "SERIALBOX_USE_BOOST_FILESYSTEM")
 endif()
 
-install(TARGETS SerialboxFilesytemTarget
-    EXPORT SerialboxTargets
-    )
+serialbox_install_targets( TARGETS SerialboxFilesytemTarget )
 
 
 #---------------------------------------- STELLA ---------------------------------------------------
@@ -391,6 +393,7 @@ if(SERIALBOX_CODE_COVERAGE)
 endif(SERIALBOX_CODE_COVERAGE)
 
 #---------------------------------------- Compilation ----------------------------------------------
+
 # Generate serialbox/core/Config.h
 set(SERIALBOX_CONFIG_FILE_DISCLAIMER "WARNING! All changes made in this file will be lost!")
 set(SERIALBOX_CXX_CONFIG_FILE_IN ${PROJECT_SOURCE_DIR}/src/serialbox/core/Config.h.cmake)
@@ -427,9 +430,9 @@ if(SERIALBOX_TESTING)
   
   # Generate utility/Config.h
   set(SERIALBOX_CPP_CONFIG_FILE_IN ${PROJECT_SOURCE_DIR}/test/utility/Config.h.cmake)
-  set(SERIALBOX_CPP_CONFIG_FILE ${CMAKE_BINARY_DIR}/test/utility/Config.h)
+  set(SERIALBOX_CPP_CONFIG_FILE ${PROJECT_BINARY_DIR}/test/utility/Config.h)
   configure_file(${SERIALBOX_CPP_CONFIG_FILE_IN} ${SERIALBOX_CPP_CONFIG_FILE})
-  include_directories(${CMAKE_BINARY_DIR}/test)
+  include_directories(${PROJECT_BINARY_DIR}/test)
   
   add_subdirectory(test)
 endif(SERIALBOX_TESTING)
@@ -449,5 +452,3 @@ if(SERIALBOX_TESTING)
 endif(SERIALBOX_TESTING)
 
 include(cmake/Packaging.cmake)
-
-

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -22,7 +22,7 @@ install(EXPORT SerialboxTargets
 )
 
 ## Generate and install SerialboxConfig.cmake
-configure_package_config_file(${CMAKE_SOURCE_DIR}/cmake/SerialboxConfig.cmake.in
+configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/SerialboxConfig.cmake.in
     "${PROJECT_BINARY_DIR}/cmake/SerialboxConfig.cmake"
     INSTALL_DESTINATION ${CMAKE_INSTALL_DIR}
     PATH_VARS CMAKE_INSTALL_DIR PYTHON_INSTALL_DIR
@@ -30,7 +30,7 @@ configure_package_config_file(${CMAKE_SOURCE_DIR}/cmake/SerialboxConfig.cmake.in
 install(FILES "${PROJECT_BINARY_DIR}/cmake/SerialboxConfig.cmake" DESTINATION cmake)
 
 ## Install SerialboxTooling.cmake
-install(FILES ${CMAKE_SOURCE_DIR}/cmake/SerialboxTooling.cmake DESTINATION cmake/)
+install(FILES ${PROJECT_SOURCE_DIR}/cmake/SerialboxTooling.cmake DESTINATION cmake/)
 
 # Generate and install SerialboxConfigVersion.cmake
 write_basic_package_version_file(
@@ -41,34 +41,17 @@ write_basic_package_version_file(
 install(FILES "${PROJECT_BINARY_DIR}/cmake/SerialboxConfigVersion.cmake" DESTINATION cmake)
 
 ## For build tree
-export(TARGETS SerialboxStatic SerialboxObjects SerialboxFilesytemTarget
-    FILE ${PROJECT_BINARY_DIR}/SerialboxTargets.cmake
-    NAMESPACE Serialbox::
-)
-if(SERIALBOX_HAS_NETCDF)
-    export(TARGETS NETCDF_TARGET
-        APPEND FILE ${PROJECT_BINARY_DIR}/SerialboxTargets.cmake
-        NAMESPACE Serialbox::
-    )
-endif()
-if(SERIALBOX_ENABLE_C)
-    export(TARGETS SerialboxCStatic SerialboxCObjects
-        APPEND FILE ${PROJECT_BINARY_DIR}/SerialboxTargets.cmake
-        NAMESPACE Serialbox::
-    )
-endif()
-if(SERIALBOX_ENABLE_FORTRAN)
-    export(TARGETS SerialboxFortranStatic SerialboxFortranObjects SerialboxFortranSerializeObjects
-        APPEND FILE ${PROJECT_BINARY_DIR}/SerialboxTargets.cmake
-        NAMESPACE Serialbox::
-    )
-endif()
 
 set(CMAKE_INSTALL_DIR ${PROJECT_SOURCE_DIR}/cmake)
 set(PYTHON_INSTALL_DIR ${PROJECT_SOURCE_DIR}/src/serialbox-python)
-configure_package_config_file(${CMAKE_SOURCE_DIR}/cmake/SerialboxConfig.cmake.in
+
+
+set( ${PROJECT_NAME}_DIR ${PROJECT_BINARY_DIR} CACHE STRING "" )
+
+configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/SerialboxConfig.cmake.in
     ${PROJECT_BINARY_DIR}/SerialboxConfig.cmake
     INSTALL_DESTINATION ${PROJECT_BINARY_DIR}
+    INSTALL_PREFIX ${PROJECT_BINARY_DIR}
     PATH_VARS CMAKE_INSTALL_DIR PYTHON_INSTALL_DIR
 )
 write_basic_package_version_file(

--- a/cmake/SerialboxConfig.cmake.in
+++ b/cmake/SerialboxConfig.cmake.in
@@ -41,11 +41,77 @@ set(SERIALBOX_BOOST_INCLUDE_DIRS "@Boost_INCLUDE_DIRS@")
 set(SERIALBOX_REQUIRED_BOOST_COMPONENTS "@REQUIRED_BOOST_COMPONENTS@")
 
 #===---------------------------------------------------------------------------------------------===
+#   Helper functions used in this file
+#====--------------------------------------------------------------------------------------------===
+
+function( serialbox_print_targets )
+  #
+  # serialbox_print_targets( targets_list )
+  #
+  #    Print exported and unavailable targets
+  #
+  message( STATUS "Serialbox exported targets:")
+  foreach( target ${ARGV} )
+    if( TARGET ${target} )
+      message( STATUS "  ${target}" )
+    else()
+      list( APPEND _unavailable_targets ${target} )
+    endif()
+  endforeach()
+  if( _unavailable_targets )
+    message( STATUS "Serialbox unavailable targets:")
+    foreach( target ${_unavailable_targets} )
+      message( STATUS "  ${target}" )
+    endforeach()
+  endif()
+endfunction()
+
+function( serialbox_alias_targets )
+  #
+  # serialbox_alias_targets( alias target_shared target_static align )
+  #
+  #    Creates ALIAS target for given targets. Prefer target_shared if availabe
+  # 
+  set( _alias ${ARGV0} )
+  set( _target_shared ${ARGV1} )
+  set( _target_static ${ARGV2} )
+  set( _align ${ARGV3} )
+  string( REPLACE "Serialbox::" "" _target_shared_build "${_target_shared}" )
+  string( REPLACE "Serialbox::" "" _target_static_build "${_target_static}" )
+  if( TARGET ${_target_shared_build} )
+    message( STATUS "  ${_alias} ${_align}--> Serialbox::${_target_shared_build}" )
+    if( NOT TARGET ${_alias} )
+      add_library( ${_alias} ALIAS ${_target_shared_build} )
+    endif()
+  elseif( TARGET ${_target_shared} AND CMAKE_VERSION GREATER 3.11 )
+    message( STATUS "  ${_alias} ${_align}--> ${_target_shared}" )
+    set_target_properties( ${_target_shared} PROPERTIES IMPORTED_GLOBAL TRUE) # required for aliasing imports
+    if( NOT TARGET ${_alias} )
+      add_library( ${_alias} ALIAS ${_target_shared} )
+    endif()
+  elseif( TARGET ${_target_static_build} )
+    message( STATUS "  ${_alias} ${_align}--> Serialbox::${_target_static_build}" )
+    if( NOT TARGET ${_alias} )
+      add_library( ${_alias} ALIAS ${_target_static_build} )
+    endif()
+  elseif( TARGET ${_target_static} AND CMAKE_VERSION GREATER 3.11 )
+    message( STATUS "  ${_alias} ${_align}--> ${_target_static}" )
+    set_target_properties( ${_target_static} PROPERTIES IMPORTED_GLOBAL TRUE) # required for aliasing imports
+    if( NOT TARGET ${_alias} )
+      add_library( ${_alias} ALIAS ${_target_static} )
+    endif()
+  endif()
+endfunction()
+
+#===---------------------------------------------------------------------------------------------===
 #   Find Serialbox libraries
 #====--------------------------------------------------------------------------------------------===
 
 # Import library targets 
-include("${CMAKE_CURRENT_LIST_DIR}/SerialboxTargets.cmake")
+if( NOT @PROJECT_NAME@_TARGETS_EXPORTED )
+  include("${CMAKE_CURRENT_LIST_DIR}/SerialboxTargets.cmake")
+  set( ${PROJECT_NAME}_TARGETS_EXPORTED TRUE )
+endif()
 
 set(SERIALBOX_HAS_SHARED_LIBRARY FALSE)
 if(TARGET Serialbox::SerialboxShared)
@@ -60,37 +126,22 @@ if(TARGET Serialbox::SerialboxFortranStatic)
   set(SERIALBOX_HAS_FORTRAN TRUE)
 endif()
 
-# Report findings
-message(STATUS "Found Serialbox version: ${SERIALBOX_VERSION}")
+### Report findings
 
-get_property(_static_lib TARGET Serialbox::SerialboxStatic PROPERTY LOCATION)
-message(STATUS "  Static serialbox: ${_static_lib}")
+message(STATUS "Found Serialbox (version: ${SERIALBOX_VERSION}) in ${PACKAGE_PREFIX_DIR}" )
 
-if(SERIALBOX_HAS_SHARED_LIBRARY)
-  get_property(_shared_lib TARGET Serialbox::SerialboxShared PROPERTY LOCATION)
-  message(STATUS "  Shared serialbox: ${_shared_lib}")
-endif()
+serialbox_print_targets(
+  Serialbox::SerialboxCStatic
+  Serialbox::SerialboxCShared
+  Serialbox::SerialboxFortranStatic
+  Serialbox::SerialboxFortranShared
+)
 
-if(SERIALBOX_HAS_C)
-  get_property(_static_lib TARGET Serialbox::SerialboxCStatic PROPERTY LOCATION)
-  message(STATUS "  Static serialbox-c: ${_static_lib}")
+### Create ALIAS targets
 
-  if(SERIALBOX_HAS_SHARED_LIBRARY)
-    get_property(_shared_lib TARGET Serialbox::SerialboxCShared PROPERTY LOCATION)
-    message(STATUS "  Shared serialbox-c: ${_shared_lib}")
-  endif()
-endif(SERIALBOX_HAS_C)
-
-if(SERIALBOX_HAS_FORTRAN)
-  get_property(_static_lib TARGET Serialbox::SerialboxFortranStatic PROPERTY LOCATION)
-  message(STATUS "  Static serialbox FORTRAN: ${_static_lib}")
-
-  if(SERIALBOX_HAS_SHARED_LIBRARY)
-    get_property(_shared_lib TARGET Serialbox::SerialboxFortranShared PROPERTY LOCATION)
-    message(STATUS "  Shared serialbox FORTRAN: ${_shared_lib}")
-  endif()
-
-endif(SERIALBOX_HAS_FORTRAN)
+message( STATUS "Serialbox ALIAS targets:" )
+serialbox_alias_targets( Serialbox::Serialbox_C       Serialbox::SerialboxCShared       Serialbox::SerialboxCStatic "      " )
+serialbox_alias_targets( Serialbox::Serialbox_Fortran Serialbox::SerialboxFortranShared Serialbox::SerialboxFortranStatic )
 
 #===---------------------------------------------------------------------------------------------===
 #   Find external libraries

--- a/cmake/SerialboxTooling.cmake
+++ b/cmake/SerialboxTooling.cmake
@@ -18,7 +18,7 @@
 #
 #   SOURCES       - Sources to preprocess
 #   OUTPUT_DIR    - Output directory of the the source files. If nothing is specified 
-#                   `${CMAKE_BINARY_DIR}/pp` is used. 
+#                   `${PROJECT_BINARY_DIR}/pp` is used. 
 #
 
 include(CMakeParseArguments)
@@ -47,8 +47,8 @@ function(serialbox_run_pp_ser)
   endif()
   
   if(NOT(output_dir))
-    # If output_dir is not set, we place them in ${CMAKE_BINARY_DIR}/pp
-    set(output_dir ${CMAKE_BINARY_DIR}/pp)  
+    # If output_dir is not set, we place them in ${PROJECT_BINARY_DIR}/pp
+    set(output_dir ${PROJECT_BINARY_DIR}/pp)  
   endif()
   
   # Create directory if it does not exist

--- a/cmake/modules/FindNetCDF.cmake
+++ b/cmake/modules/FindNetCDF.cmake
@@ -45,8 +45,6 @@ if(NetCDF_FOUND)
   target_include_directories(NETCDF_TARGET INTERFACE ${NETCDF_INCLUDES})
   target_compile_definitions(NETCDF_TARGET INTERFACE "SERIALBOX_HAS_NETCDF")
   target_link_libraries(NETCDF_TARGET INTERFACE ${NETCDF_LIBRARIES})
-  install(TARGETS NETCDF_TARGET 
-            EXPORT SerialboxTargets)
 else()
   # If the package was required we abort the process
   if(${NetCDF_FIND_REQUIRED})

--- a/cmake/modules/SerialboxInstallTargets.cmake
+++ b/cmake/modules/SerialboxInstallTargets.cmake
@@ -1,0 +1,36 @@
+##===------------------------------------------------------------------------------*- CMake -*-===##
+##
+##                                   S E R I A L B O X
+##
+## This file is distributed under terms of BSD license. 
+## See LICENSE.txt for more information.
+##
+##===------------------------------------------------------------------------------------------===##
+
+#
+# serialbox_install_targets( TARGETS [ target1 [ target2 ... ] )
+#
+#  Arguments:
+#
+#       TARGETS [target1 [ target2 ...] ]   Targets to be exported and installed.
+#
+function( serialbox_install_targets )
+  cmake_parse_arguments( serialbox_install_targets "" "" "TARGETS" ${ARGN})
+  
+  set(target_list ${serialbox_install_targets_TARGETS})
+
+  foreach( target ${target_list} )
+    if( TARGET ${target} )
+      install(TARGETS ${target}
+        EXPORT SerialboxTargets
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+      )
+      export( TARGETS ${target}
+        APPEND FILE ${PROJECT_BINARY_DIR}/SerialboxTargets.cmake
+        NAMESPACE Serialbox::
+      )
+      add_library( Serialbox::${target} ALIAS ${target} )
+    endif()
+  endforeach()
+endfunction()

--- a/cmake/modules/SerialboxTestScript.cmake
+++ b/cmake/modules/SerialboxTestScript.cmake
@@ -15,7 +15,7 @@ include(CMakeParseArguments)
 ## Setup the test_script.
 ##
 function(serialbox_test_init)
-  set(SERIALBOX_TEST_SCRIPT ${CMAKE_BINARY_DIR}/run_tests.sh CACHE PATH "Test script path")
+  set(SERIALBOX_TEST_SCRIPT ${PROJECT_BINARY_DIR}/run_tests.sh CACHE PATH "Test script path")
   file(WRITE ${SERIALBOX_TEST_SCRIPT} "#!/bin/bash\n")
   file(APPEND ${SERIALBOX_TEST_SCRIPT} "res=0\n")
 endfunction(serialbox_test_init)
@@ -40,7 +40,7 @@ function(serialbox_add_test)
   cmake_parse_arguments(serialbox_add_test "" "NAME" "TARGET;EXECUTABLE" ${ARGN})
   
   set(target_list ${serialbox_add_test_TARGET})
-  set(exectuable_list ${serialbox_add_test_EXECUTABLE})
+  set(executable_list ${serialbox_add_test_EXECUTABLE})
   set(name ${serialbox_add_test_NAME})
 
   set(test_already_added_to_ctest FALSE)
@@ -64,10 +64,10 @@ function(serialbox_add_test)
     set(test_already_added_to_ctest TRUE)
   endif()
   
-  if(exectuable_list)
+  if(executable_list)
     list(GET exectuable_list 0 exectuable)
     
-    set(args ${exectuable_list})
+    set(args ${executable_list})
     list(REMOVE_AT args 0)
     
     set(flat_args "")
@@ -76,7 +76,7 @@ function(serialbox_add_test)
     endforeach()
     
     if(NOT(name))
-      list(GET exectuable_list 1 name_with_whitespaces)
+      list(GET executable_list 1 name_with_whitespaces)
       string(STRIP ${name_with_whitespaces} name)
     endif()
   
@@ -86,7 +86,7 @@ function(serialbox_add_test)
     file(APPEND ${SERIALBOX_TEST_SCRIPT} "res=$((res || ret ))\n")
     
     if(NOT(test_already_added_to_ctest))
-      add_test(NAME ${name} COMMAND ${exectuable_list})
+      add_test(NAME ${name} COMMAND ${executable_list})
     endif()
   endif()
 
@@ -106,7 +106,7 @@ function(serialbox_test_end)
        "  printf \"\\n  ALL TESTS PASSED\\n\\n\"\n"
        "fi\n"
        "exit $res")
-  file(INSTALL ${SERIALBOX_TEST_SCRIPT} DESTINATION ${CMAKE_BINARY_DIR}/install
+  file(INSTALL ${SERIALBOX_TEST_SCRIPT} DESTINATION ${PROJECT_BINARY_DIR}/install
        FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ)
 endfunction(serialbox_test_end)
 

--- a/cmake/modules/SerialboxTestScript.cmake
+++ b/cmake/modules/SerialboxTestScript.cmake
@@ -2,7 +2,7 @@
 ##
 ##                                   S E R I A L B O X
 ##
-## This file is distributed under terms of BSD license. 
+## This file is distributed under terms of BSD license.
 ## See LICENSE.txt for more information.
 ##
 ##===------------------------------------------------------------------------------------------===##
@@ -22,23 +22,23 @@ endfunction(serialbox_test_init)
 
 ## serialbox_add_test
 ## ------------------
-## 
+##
 ## Add a unittest to CTest and the test_script.
 ##
-##    TARGET:STRINGS=<>          - The first string in the list will be treated as the CMake target 
+##    TARGET:STRINGS=<>          - The first string in the list will be treated as the CMake target
 ##                                 to run i.e the file $<TARGET_FILE:target> will be added to CTest
-##                                 while the remaining elements in the list are passed as 
+##                                 while the remaining elements in the list are passed as
 ##                                 command-line arguments.
-##    EXECUTABLE:STRINGS=<>      - The first string in the list will be treated as the exectuable 
-##                                 to run while the remaining elements in the list are passed as 
+##    EXECUTABLE:STRINGS=<>      - The first string in the list will be treated as the executable
+##                                 to run while the remaining elements in the list are passed as
 ##                                 command-line arguments.
 ##    NAME:STRING=<>             - [optional]: Name of the test. If the name is not provided either
-##                                 the CMake target or the second argument to EXECUTABLE will be 
+##                                 the CMake target or the second argument to EXECUTABLE will be
 ##                                 used.
 ##
 function(serialbox_add_test)
   cmake_parse_arguments(serialbox_add_test "" "NAME" "TARGET;EXECUTABLE" ${ARGN})
-  
+
   set(target_list ${serialbox_add_test_TARGET})
   set(executable_list ${serialbox_add_test_EXECUTABLE})
   set(name ${serialbox_add_test_NAME})
@@ -47,44 +47,44 @@ function(serialbox_add_test)
 
   if(target_list)
     list(GET target_list 0 target)
-    
+
     set(args ${target_list})
     list(REMOVE_AT args 0)
-    
+
     set(flat_args "")
     foreach(arg ${args})
       set(flat_args "${flat_args} ${arg}")
     endforeach()
-    
+
     if(NOT(name))
       set(name ${target})
     endif()
-    
+
     add_test(NAME ${name} COMMAND $<TARGET_FILE:${target}> ${flat_args})
     set(test_already_added_to_ctest TRUE)
   endif()
-  
+
   if(executable_list)
-    list(GET exectuable_list 0 exectuable)
-    
+    list(GET executable_list 0 exectuable)
+
     set(args ${executable_list})
     list(REMOVE_AT args 0)
-    
+
     set(flat_args "")
     foreach(arg ${args})
       set(flat_args "${flat_args} ${arg}")
     endforeach()
-    
+
     if(NOT(name))
       list(GET executable_list 1 name_with_whitespaces)
       string(STRIP ${name_with_whitespaces} name)
     endif()
-  
+
     file(APPEND ${SERIALBOX_TEST_SCRIPT} "\n${exectuable} ${flat_args}\n")
     file(APPEND ${SERIALBOX_TEST_SCRIPT} "ret=\$?\n")
     file(APPEND ${SERIALBOX_TEST_SCRIPT} "if [ $ret -ne 0 ] ; then\n echo \"Error: problem found in Unittest\"\nfi\n")
     file(APPEND ${SERIALBOX_TEST_SCRIPT} "res=$((res || ret ))\n")
-    
+
     if(NOT(test_already_added_to_ctest))
       add_test(NAME ${name} COMMAND ${executable_list})
     endif()
@@ -99,7 +99,7 @@ endfunction(serialbox_add_test)
 ## Append last statements to the test_script.
 ##
 function(serialbox_test_end)
-  file(APPEND ${SERIALBOX_TEST_SCRIPT} 
+  file(APPEND ${SERIALBOX_TEST_SCRIPT}
        "\nif [ $res -ne 0 ]; then\n"
        "  printf \"\\n  >>>>>>>>>>>>>>>> TESTS FAILED <<<<<<<<<<<<<<<<\\n\\n\"\n"
        "else\n"
@@ -109,4 +109,3 @@ function(serialbox_test_end)
   file(INSTALL ${SERIALBOX_TEST_SCRIPT} DESTINATION ${PROJECT_BINARY_DIR}/install
        FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ)
 endfunction(serialbox_test_end)
-

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -46,15 +46,15 @@ add_custom_target(docs
   COMMAND ${SPHINX_EXECUTABLE} -b html -d ${CMAKE_CURRENT_SOURCE_DIR}/sphinx/_build/doctrees 
           ${CMAKE_CURRENT_SOURCE_DIR}/sphinx/ ${CMAKE_CURRENT_SOURCE_DIR}/sphinx/_build/html
   COMMAND ${CMAKE_COMMAND} -E copy_directory
-          ${CMAKE_SOURCE_DIR}/docs/doxygen/html
-          ${CMAKE_SOURCE_DIR}/docs/sphinx/_build/html/_doxygen/html
+          ${PROJECT_SOURCE_DIR}/docs/doxygen/html
+          ${PROJECT_SOURCE_DIR}/docs/sphinx/_build/html/_doxygen/html
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Generating documentation" VERBATIM
 )
 
 ## Generate & deploy documentation
 add_custom_target(deploy-docs
-  COMMAND ${CMAKE_SOURCE_DIR}/tools/deploy-docs.sh
+  COMMAND ${PROJECT_SOURCE_DIR}/tools/deploy-docs.sh
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Deploying documentation" VERBATIM
 )

--- a/docs/sphinx/Usage.rst
+++ b/docs/sphinx/Usage.rst
@@ -77,5 +77,5 @@ source code using the pp_ser.py script.
 Function arguments::
 
   SOURCES       - Sources to preprocess
-  OUTPUT_DIR    - Output directory of the the source files. If nothing is specified ${CMAKE_BINARY_DIR}/pp is used. 
+  OUTPUT_DIR    - Output directory of the the source files. If nothing is specified ${PROJECT_BINARY_DIR}/pp is used. 
 

--- a/examples/fortran/perturbation/CMakeLists.txt
+++ b/examples/fortran/perturbation/CMakeLists.txt
@@ -43,8 +43,8 @@ endif()
 
 #
 # Here we preprocess all the source files, using the preprocesser script pp_ser.py, and store them 
-# in ${CMAKE_SOURCE_DIR}/pp.
-set(PP_OUTPUT ${CMAKE_SOURCE_DIR}/pp)
+# in ${PROJECT_SOURCE_DIR}/pp.
+set(PP_OUTPUT ${PROJECT_SOURCE_DIR}/pp)
 serialbox_run_pp_ser(SOURCES main_producer.F90  
                              main_consumer.F90
                              main_consumer_perturb.F90
@@ -73,5 +73,5 @@ set_target_properties(fortran_consumer_perturb PROPERTIES LINKER_LANGUAGE ${exam
 #
 # Finally, copy our run script to the build directory
 #
-file(COPY ${CMAKE_SOURCE_DIR}/run.sh DESTINATION ${CMAKE_BINARY_DIR})
+file(COPY ${PROJECT_SOURCE_DIR}/run.sh DESTINATION ${PROJECT_BINARY_DIR})
 

--- a/examples/fortran/perturbation_netcdf/CMakeLists.txt
+++ b/examples/fortran/perturbation_netcdf/CMakeLists.txt
@@ -47,9 +47,9 @@ endif()
 
 #
 # Here we preprocess all the source files, using the preprocesser script pp_ser.py, and store them 
-# in ${CMAKE_SOURCE_DIR}/pp.
+# in ${PROJECT_SOURCE_DIR}/pp.
 
-set(PP_OUTPUT ${CMAKE_SOURCE_DIR}/pp)
+set(PP_OUTPUT ${PROJECT_SOURCE_DIR}/pp)
 serialbox_run_pp_ser(SOURCES main_producer.F90  
                              main_consumer.F90
                              main_consumer_perturb.F90
@@ -78,5 +78,5 @@ set_target_properties(fortran_consumer_perturb_netcdf PROPERTIES LINKER_LANGUAGE
 #
 # Finally, copy our run script to the build directory
 #
-file(COPY ${CMAKE_SOURCE_DIR}/run.sh DESTINATION ${CMAKE_BINARY_DIR})
+file(COPY ${PROJECT_SOURCE_DIR}/run.sh DESTINATION ${PROJECT_BINARY_DIR})
 

--- a/examples/fortran/simple/CMakeLists.txt
+++ b/examples/fortran/simple/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries( simple_m_ser
                         SerialboxFortranStatic 
                         ${CMAKE_THREAD_LIBS_INIT}
                         )
-target_include_directories(simple_m_ser PUBLIC ${CMAKE_BINARY_DIR}/src/serialbox-fortran)
+target_include_directories(simple_m_ser PUBLIC ${PROJECT_BINARY_DIR}/src/serialbox-fortran)
 if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR ${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
     set_target_properties( simple_m_ser PROPERTIES LINKER_LANGUAGE Fortran)
 endif()

--- a/examples/gridtools/smagorinsky/CMakeLists.txt
+++ b/examples/gridtools/smagorinsky/CMakeLists.txt
@@ -18,7 +18,7 @@ project(SerialboxSmagorinskyExample CXX)
 # command-line).
 #
 if(NOT(DEFINED SERIALBOX_ROOT))
-	set(SERIALBOX_ROOT "${CMAKE_SOURCE_DIR}/../../../install")
+	set(SERIALBOX_ROOT "${PROJECT_SOURCE_DIR}/../../../install")
 endif()
 
 #
@@ -26,7 +26,7 @@ endif()
 # Usually you want to bundle this module with your own project and therefore we copied it into 
 # "cmake/". We need to tell CMake about this.
 #
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 #
 # We call the find_package-module of Serialbox and gridtools and set the include directories

--- a/src/serialbox-c/CMakeLists.txt
+++ b/src/serialbox-c/CMakeLists.txt
@@ -58,7 +58,7 @@ if(SERIALBOX_ENABLE_C)
   add_library(SerialboxCObjects OBJECT ${SOURCES})
   target_include_directories(SerialboxCObjects
     PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
         $<INSTALL_INTERFACE:include>
     )
   target_link_libraries(SerialboxCObjects PUBLIC Boost::boost)
@@ -78,18 +78,11 @@ if(SERIALBOX_ENABLE_C)
     set_property(TARGET SerialboxCObjects PROPERTY POSITION_INDEPENDENT_CODE 1)
   endif()
   
-  install(TARGETS SerialboxCStatic SerialboxCObjects
-    EXPORT SerialboxTargets
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    )
-  
-  if(BUILD_SHARED_LIBS)
-    install(TARGETS SerialboxCShared
-        EXPORT SerialboxTargets
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        )
-  endif()
+  serialbox_install_targets( TARGETS 
+    SerialboxCStatic
+    SerialboxCShared
+    SerialboxCObjects
+  )
+
 endif()
 

--- a/src/serialbox-fortran/CMakeLists.txt
+++ b/src/serialbox-fortran/CMakeLists.txt
@@ -15,7 +15,7 @@ if(SERIALBOX_ENABLE_FORTRAN)
   add_library(SerialboxFortranSerializeObjects OBJECT ${SOURCES_FORTRAN_SERIALIZE})
   target_include_directories(SerialboxFortranSerializeObjects
     PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
         $<INSTALL_INTERFACE:include>
     )
   
@@ -38,11 +38,6 @@ if(SERIALBOX_ENABLE_FORTRAN)
   target_link_libraries(SerialboxFortranStatic PUBLIC SerialboxCStatic)
   set_target_properties(SerialboxFortranStatic PROPERTIES VERSION ${Serialbox_VERSION_STRING})
 
-  install(TARGETS SerialboxFortranStatic SerialboxFortranObjects SerialboxFortranSerializeObjects
-    EXPORT SerialboxTargets
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    )
 
   if(BUILD_SHARED_LIBS)
     set_target_properties( SerialboxFortranSerializeObjects PROPERTIES POSITION_INDEPENDENT_CODE ON )
@@ -51,14 +46,16 @@ if(SERIALBOX_ENABLE_FORTRAN)
     target_link_libraries(SerialboxFortranShared PUBLIC SerialboxFortranObjects)
     target_link_libraries(SerialboxFortranShared PUBLIC SerialboxFortranSerializeObjects)
     target_link_libraries(SerialboxFortranShared PUBLIC SerialboxCShared)
-    set_target_properties(SerialboxFortranShared PROPERTIES VERSION ${Serialbox_VERSION_STRING})
-    
-    install(TARGETS SerialboxFortranShared
-      EXPORT SerialboxTargets
-      LIBRARY DESTINATION lib
-      ARCHIVE DESTINATION lib
-      )
+    set_target_properties(SerialboxFortranShared PROPERTIES VERSION ${Serialbox_VERSION_STRING})    
   endif()
+
+  serialbox_install_targets( TARGETS 
+    SerialboxFortranStatic
+    SerialboxFortranShared
+    SerialboxFortranObjects
+    SerialboxFortranSerializeObjects
+  )
+
 
   # Install mod files
   foreach(source ${SOURCES_FORTRAN} ${SOURCES_FORTRAN_SERIALIZE})

--- a/src/serialbox-python/CMakeLists.txt
+++ b/src/serialbox-python/CMakeLists.txt
@@ -11,14 +11,14 @@ cmake_minimum_required(VERSION 3.12)
 
 ## Install ppser
 install(
-  FILES ${CMAKE_SOURCE_DIR}/src/serialbox-python/pp_ser/pp_ser.py
+  FILES ${PROJECT_SOURCE_DIR}/src/serialbox-python/pp_ser/pp_ser.py
   DESTINATION python/pp_ser
   PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
 )
 
 ## Install compare
 install(
-  FILES ${CMAKE_SOURCE_DIR}/src/serialbox-python/compare/compare.py
+  FILES ${PROJECT_SOURCE_DIR}/src/serialbox-python/compare/compare.py
   DESTINATION python/compare
   PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
 )
@@ -36,23 +36,23 @@ if(SERIALBOX_ENABLE_PYTHON)
   endif()
 
   file(GLOB_RECURSE SERIALBOX_PYTHON_SOURCE
-       ${CMAKE_SOURCE_DIR}/src/serialbox-python/
-       ${CMAKE_SOURCE_DIR}/src/serialbox-python/*.py
-       ${CMAKE_SOURCE_DIR}/src/serialbox-python/serialbox/*.py)
+       ${PROJECT_SOURCE_DIR}/src/serialbox-python/
+       ${PROJECT_SOURCE_DIR}/src/serialbox-python/*.py
+       ${PROJECT_SOURCE_DIR}/src/serialbox-python/serialbox/*.py)
 
   set(REMOVE_OBSOLETE_SYMLINKS_OR_NOP
-            find -L ${CMAKE_SOURCE_DIR}/src/serialbox-python/serialbox -type l -delete)
+            find -L ${PROJECT_SOURCE_DIR}/src/serialbox-python/serialbox -type l -delete)
 
   add_custom_target(SerialboxPython
                     COMMAND ${REMOVE_OBSOLETE_SYMLINKS_OR_NOP}
                     COMMAND ${CMAKE_COMMAND} -E copy_directory
-                    ${CMAKE_SOURCE_DIR}/src/serialbox-python/serialbox
-                    ${CMAKE_BINARY_DIR}/src/serialbox-python/serialbox
+                    ${PROJECT_SOURCE_DIR}/src/serialbox-python/serialbox
+                    ${PROJECT_BINARY_DIR}/src/serialbox-python/serialbox
                     DEPENDS "${SERIALBOX_PYTHON_SOURCE}")
   add_dependencies(SerialboxCShared SerialboxPython)
 
   # Install python source
-  install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/serialbox-python/serialbox/
+  install(DIRECTORY ${PROJECT_SOURCE_DIR}/src/serialbox-python/serialbox/
           DESTINATION python/serialbox
           FILES_MATCHING PATTERN "*.py"
           PATTERN "*__pycache__*" EXCLUDE)
@@ -75,19 +75,19 @@ if(SERIALBOX_ENABLE_SDB)
   endif()
 
   file(GLOB_RECURSE SDB_PYTHON_SOURCE
-       ${CMAKE_SOURCE_DIR}/src/serialbox-python/
-       ${CMAKE_SOURCE_DIR}/src/serialbox-python/*.py
-       ${CMAKE_SOURCE_DIR}/src/serialbox-python/sdb/*.py)
+       ${PROJECT_SOURCE_DIR}/src/serialbox-python/
+       ${PROJECT_SOURCE_DIR}/src/serialbox-python/*.py
+       ${PROJECT_SOURCE_DIR}/src/serialbox-python/sdb/*.py)
 
   add_custom_target(sdbPython
                     COMMAND ${CMAKE_COMMAND} -E copy_directory
-                    ${CMAKE_SOURCE_DIR}/src/serialbox-python/sdb
-                    ${CMAKE_BINARY_DIR}/src/serialbox-python/sdb
+                    ${PROJECT_SOURCE_DIR}/src/serialbox-python/sdb
+                    ${PROJECT_BINARY_DIR}/src/serialbox-python/sdb
                     DEPENDS "${SDB_PYTHON_SOURCE}")
   add_dependencies(SerialboxPython sdbPython)
 
   # Install python source
-  install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/serialbox-python/sdb/
+  install(DIRECTORY ${PROJECT_SOURCE_DIR}/src/serialbox-python/sdb/
           DESTINATION python/sdb
           FILES_MATCHING PATTERN "*.py" PATTERN "*.png"
           PATTERN "*__pycache__*" EXCLUDE)

--- a/src/serialbox/core/CMakeLists.txt
+++ b/src/serialbox/core/CMakeLists.txt
@@ -74,7 +74,7 @@ set(SOURCES
 add_library(SerialboxObjects OBJECT ${SOURCES})
 target_include_directories(SerialboxObjects
     PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
         $<INSTALL_INTERFACE:include>
     )
 target_link_libraries(SerialboxObjects PRIVATE Boost::boost)
@@ -105,16 +105,8 @@ if(BUILD_SHARED_LIBS)
     set_property(TARGET SerialboxObjects PROPERTY POSITION_INDEPENDENT_CODE 1)
 endif()
 
-install(TARGETS SerialboxStatic SerialboxObjects
-    EXPORT SerialboxTargets
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    )
-
-if(BUILD_SHARED_LIBS)
-    install(TARGETS SerialboxShared
-        EXPORT SerialboxTargets
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        )
-endif()
+serialbox_install_targets( TARGETS 
+  SerialboxStatic
+  SerialboxObjects
+  SerialboxShared
+)

--- a/test/serialbox-fortran/CMakeLists.txt
+++ b/test/serialbox-fortran/CMakeLists.txt
@@ -29,7 +29,7 @@ file(WRITE ${generated_src_dir}/testSuites.inc "")
   
 #SerialboxFortran mod files
 #TODO: is there a better way to do this
-include_directories(${CMAKE_BINARY_DIR}/src/serialbox-fortran)
+include_directories(${PROJECT_BINARY_DIR}/src/serialbox-fortran)
 include_directories(${generated_src_dir} ${PFUNIT_INCLUDE_DIRS})
   
 set(_test_sources)

--- a/test/utility/CMakeLists.txt
+++ b/test/utility/CMakeLists.txt
@@ -25,7 +25,7 @@ set(SOURCES
 )
 
 add_library(SerialboxUnittestUtilityObjects OBJECT ${SOURCES})
-target_include_directories(SerialboxUnittestUtilityObjects PUBLIC ${CMAKE_SOURCE_DIR}/test)
+target_include_directories(SerialboxUnittestUtilityObjects PUBLIC ${PROJECT_SOURCE_DIR}/test)
 target_link_libraries(SerialboxUnittestUtilityObjects PUBLIC Boost::boost)
 target_link_libraries(SerialboxUnittestUtilityObjects PUBLIC gtest_main)
 target_link_libraries(SerialboxUnittestUtilityObjects PUBLIC SerialboxFilesytemTarget)


### PR DESCRIPTION
This PR allows Serialbox to be used in CMake superbuild projects,
so that one could have code like
```
add_subdirectory( serialbox2 )  # --> will set "Serialbox_DIR" in cache
add_subdirectory( project_using_serialbox )
```
and within `project_using_serialbox` we have
```
find_package( Serialbox )  # --> will use Serialbox_DIR as default hint
```
Most issues were related to use of `${CMAKE_BINARY_DIR}` and `${CMAKE_SOURCE_DIR}` which reflect the top-level CMake project rather than `${PROJECT_BINARY_DIR}` and `${PROJECT_SOURCE_DIR}` which reflect the most recent project.

As a result it could be that certain products are no longer in a previously expected directory now, as I am not able to test everything

---
Moreover in this PR I have created alias targets (if possible) `Serialbox::Serialbox_C` and `Serialbox::Serialbox_Fortran` that prefer the shared versions `Serialbox::SerialboxCShared` and `Serialbox::SerialboxFortranShared` over the static versions `Serialbox::SerialboxCStatic` and `Serialbox::SerialboxFortranStatic`

In the client software you can then just use the alias target instead.