### PR TITLE
[Fortran] [FTG] Support for strings in Fortran

### DIFF
--- a/src/serialbox-fortran/m_ser_ftg_cmp.f90
+++ b/src/serialbox-fortran/m_ser_ftg_cmp.f90
@@ -1205,10 +1205,12 @@ SUBROUTINE ftg_compare_string(fieldname, field, result, failure_count, fieldname
       IF (.NOT. ftg_cmp_quiet) THEN
         WRITE (*,'(A,A,A,A)') TRIM(ftg_cmp_message_prefix), " ", TRIM(fieldname_print), " : Not equal"
         IF (ftg_cmp_max_print_deviations > 0) THEN
-          WRITE (*,'(A)',advance="no") "  -> expected: "
+          WRITE (*,'(A)',advance="no") '  -> expected: "'
           WRITE (*,'(A)',advance="no") TRIM(stored_field)
-          WRITE (*,'(A)',advance="no") ", actual: "
-          WRITE (*,'(A)') TRIM(field)
+          WRITE (*,'(A)') '"'
+          WRITE (*,'(A)',advance="no") '       actual: "'
+          WRITE (*,'(A)',advance="no") TRIM(field)
+          WRITE (*,'(A)') '"'
         END IF 
       END IF
     END IF
@@ -1216,7 +1218,7 @@ SUBROUTINE ftg_compare_string(fieldname, field, result, failure_count, fieldname
   
   IF (result) THEN
     IF (.NOT. ftg_cmp_quiet .AND. ftg_cmp_print_when_equal) THEN
-      WRITE (*,'(A,A,A,A,A,A)') TRIM(ftg_cmp_message_prefix), " ", TRIM(fieldname_print), " : OK (", TRIM(field), ")"
+      WRITE (*,'(A,A,A,A,A,A)') TRIM(ftg_cmp_message_prefix), ' ', TRIM(fieldname_print), ' : OK ("', TRIM(field), '")'
     END IF
   ELSE
     IF (PRESENT(failure_count)) THEN

--- a/src/serialbox-fortran/m_ser_ftg_cmp.f90
+++ b/src/serialbox-fortran/m_ser_ftg_cmp.f90
@@ -78,6 +78,7 @@ END INTERFACE ftg_cmp_print_deviations
 
 INTERFACE ftg_compare
   MODULE PROCEDURE &
+    ftg_compare_string, &
     ftg_compare_logical_0d, &
     ftg_compare_logical_1d, &
     ftg_compare_logical_2d, &
@@ -1170,6 +1171,60 @@ END SUBROUTINE ftg_cmp_print_deviations_double_4d
 
 !=============================================================================
 !=============================================================================
+
+SUBROUTINE ftg_compare_string(fieldname, field, result, failure_count, fieldname_alias)
+  CHARACTER(LEN=*), INTENT(IN)           :: fieldname
+  CHARACTER(LEN=*), INTENT(IN)           :: field
+  LOGICAL, INTENT(OUT)                   :: result
+  INTEGER, INTENT(INOUT), OPTIONAL       :: failure_count
+  CHARACTER(LEN=*), INTENT(IN), OPTIONAL :: fieldname_alias
+  CHARACTER(LEN=256)                     :: fieldname_print
+  CHARACTER(LEN=LEN(field))              :: stored_field
+  
+  IF (PRESENT(fieldname_alias)) THEN
+    fieldname_print = fieldname_alias
+  ELSE
+    fieldname_print = fieldname
+  END IF
+  
+  result = .TRUE.
+  
+  IF (.NOT. ftg_field_exists(fieldname)) THEN
+    IF (ftg_cmp_count_missing_field_as_failure) THEN
+      result = .FALSE.
+    END IF
+    IF (.NOT. ftg_cmp_quiet) THEN
+      WRITE (*,'(A,A,A,A)') TRIM(ftg_cmp_message_prefix), " ", TRIM(fieldname_print), " : Don't exist in Serializer"
+    END IF
+  ELSE
+    CALL ftg_read(fieldname, stored_field)
+    IF (.NOT. ftg_cmp_size(fieldname, (/ LEN(field) /), fieldname_print)) THEN
+      result = .FALSE.
+    ELSE IF (field /= stored_field) THEN
+      result = .FALSE.
+      IF (.NOT. ftg_cmp_quiet) THEN
+        WRITE (*,'(A,A,A,A)') TRIM(ftg_cmp_message_prefix), " ", TRIM(fieldname_print), " : Not equal"
+        IF (ftg_cmp_max_print_deviations > 0) THEN
+          WRITE (*,'(A)',advance="no") "  -> expected: "
+          WRITE (*,'(A)',advance="no") TRIM(stored_field)
+          WRITE (*,'(A)',advance="no") ", actual: "
+          WRITE (*,'(A)') TRIM(field)
+        END IF 
+      END IF
+    END IF
+  END IF
+  
+  IF (result) THEN
+    IF (.NOT. ftg_cmp_quiet .AND. ftg_cmp_print_when_equal) THEN
+      WRITE (*,'(A,A,A,A,A,A)') TRIM(ftg_cmp_message_prefix), " ", TRIM(fieldname_print), " : OK (", TRIM(field), ")"
+    END IF
+  ELSE
+    IF (PRESENT(failure_count)) THEN
+      failure_count = failure_count + 1
+    END IF
+  END IF
+    
+END SUBROUTINE ftg_compare_string
 
 SUBROUTINE ftg_compare_logical_0d(fieldname, field, result, failure_count, fieldname_alias)
   CHARACTER(LEN=*), INTENT(IN)           :: fieldname

--- a/test/serialbox-fortran/ser_ftg_cmp_test.pf
+++ b/test/serialbox-fortran/ser_ftg_cmp_test.pf
@@ -353,5 +353,39 @@ CONTAINS
       CALL ftg_destroy_serializer()      
     
     END SUBROUTINE testNotExists
+    
+  @Test
+    SUBROUTINE testStrings()
+    
+      LOGICAL :: result
+      INTEGER :: failure_count
+    
+      CHARACTER(10) :: w_testfield_len10
+      
+      CHARACTER(len=*), PARAMETER :: base_name = 'test_strings'
+    
+      result = .FALSE.
+      failure_count = 0
+      
+      
+      w_testfield_len10 = 'abcde'
+
+      CALL ftg_set_serializer(dir, base_name, 'w')
+      CALL ftg_write("testfield_len10", w_testfield_len10)
+      CALL ftg_destroy_serializer()
+      
+      CALL ftg_set_serializer(dir, base_name, 'r')
+      CALL ftg_compare("testfield_len10", "abcde     ", result, failure_count)
+      @assertTrue(result)
+      @assertEqual(0, failure_count)
+      CALL ftg_compare("testfield_len10", "abcdedefgh", result, failure_count)
+      @assertFalse(result)
+      @assertEqual(1, failure_count)
+      CALL ftg_compare("testfield_len10", "abcde", result, failure_count)
+      @assertFalse(result)
+      @assertEqual(2, failure_count)
+      CALL ftg_destroy_serializer()
+    
+    END SUBROUTINE testStrings    
       
 END MODULE ser_ftg_cmp_test

--- a/test/serialbox-fortran/ser_ftg_test.pf
+++ b/test/serialbox-fortran/ser_ftg_test.pf
@@ -1111,6 +1111,35 @@ CONTAINS
       @assertTrue(ftg_field_exists("testc2"))
       CALL ftg_destroy_serializer()
       
-    END SUBROUTINE testTypeComponents  
+    END SUBROUTINE testTypeComponents
+    
+  @Test
+    SUBROUTINE testStrings()
+    
+      CHARACTER(10) :: w_testfield_len10, r_testfield_len10
+      
+      CHARACTER(len=*), PARAMETER :: base_name = 'test_strings'
+      
+      w_testfield_len10 = 'abcde'
+
+      CALL ftg_set_serializer(dir, base_name, 'w')
+      CALL ftg_write("testfield_len10", w_testfield_len10)
+      CALL ftg_destroy_serializer()
+      
+      CALL ftg_set_serializer(dir, base_name, 'r')
+      
+      @assertTrue(ftg_field_exists("testfield_len10"))
+      @assertEqual((/ 10, 0, 0, 0 /), ftg_get_size("testfield_len10"))
+      
+      CALL ftg_read("testfield_len10", r_testfield_len10)
+      
+      CALL ftg_destroy_serializer()
+      
+      @assertEqual('a', CHAR(ICHAR('a')))
+      @assertEqual(w_testfield_len10, r_testfield_len10)
+      @assertEqual('abcde     ', r_testfield_len10)
+      @assertEqual('abcde', TRIM(r_testfield_len10))
+    
+    END SUBROUTINE testStrings
       
 END MODULE ser_ftg_test

--- a/test/serialbox-fortran/serialbox_test.pf
+++ b/test/serialbox-fortran/serialbox_test.pf
@@ -838,5 +838,36 @@ CONTAINS
       CALL fs_destroy_savepoint(savepoint)
     
     END SUBROUTINE testSavepointMetainfo    
+    
+@Test
+    SUBROUTINE testStrings()
+    
+      TYPE(t_serializer) :: serializer
+      CHARACTER(10) :: w_testfield_len10, r_testfield_len10
+      
+      CHARACTER(len=*), PARAMETER :: base_name = 'test_strings'
+      
+      w_testfield_len10 = 'abcde'
+
+      CALL fs_create_serializer(dir, base_name, 'w', serializer)
+      CALL fs_write_field(serializer, savepoint, "testfield_len10", w_testfield_len10)
+      CALL fs_destroy_serializer(serializer)
+      
+      CALL fs_create_serializer(dir, base_name, 'r', serializer)
+      
+      @assertTrue(fs_field_exists(serializer, "testfield_len10"))
+      @assertEqual(10, fs_get_total_size(serializer, "testfield_len10"))
+      @assertEqual((/ 10, 0, 0, 0 /), fs_get_size(serializer, "testfield_len10"))
+      
+      CALL fs_read_field(serializer, savepoint, "testfield_len10", r_testfield_len10)
+      
+      CALL fs_destroy_serializer(serializer)
+      
+      @assertEqual('a', CHAR(ICHAR('a')))
+      @assertEqual(w_testfield_len10, r_testfield_len10)
+      @assertEqual('abcde     ', r_testfield_len10)
+      @assertEqual('abcde', TRIM(r_testfield_len10))
+    
+    END SUBROUTINE testStrings
 
 END MODULE serialbox_test


### PR DESCRIPTION
`CHARACTER`s are converted with `IACHAR` and stored as integer array. Conversion to C strings would be too complicated, I guess.